### PR TITLE
feat(insights): visitor analytics, trends dashboard, CSV export, and privacy policy update

### DIFF
--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -31,6 +31,7 @@
     "react-dom": "^19.2.4",
     "react-map-gl": "^8.1.0",
     "react-router-dom": "^7.13.1",
+    "recharts": "^3.8.1",
     "use-supercluster": "^1.2.0",
     "zustand": "^5.0.11"
   },

--- a/apps/client/src/components/layout/App.jsx
+++ b/apps/client/src/components/layout/App.jsx
@@ -18,10 +18,13 @@ import HolidaysPage from "@/features/dashboard/pages/HolidaysPage";
 import ReportingPage from "@/features/dashboard/pages/ReportingPage";
 import MapPage from "@/features/map/pages/MapPage";
 import FeatureFlagsPage from "@/features/feature-flags/pages/FeatureFlagsPage";
+import InsightsPage from "@/features/insights/pages/InsightsPage";
+import useVisitorHeartbeat from "@/features/insights/hooks/useVisitorHeartbeat";
 import { useFeatureFlagStore } from "@/store/featureFlagStore";
 
 const App = () => {
   const fetchFlags = useFeatureFlagStore((state) => state.fetchFlags);
+  useVisitorHeartbeat();
   useEffect(() => { fetchFlags(); }, [fetchFlags]);
   return (
     <Routes>
@@ -37,6 +40,7 @@ const App = () => {
               <Route path="/dashboard/products" element={<ProductsPage />} />
               <Route path="/dashboard/holidays" element={<HolidaysPage />} />
               <Route path="/dashboard/reporting" element={<ReportingPage />} />
+              <Route path="/dashboard/insights" element={<InsightsPage />} />
               <Route
                 path="/dashboard/features"
                 element={<FeatureFlagsPage />}

--- a/apps/client/src/components/ui/TermsAndPrivacyModal.jsx
+++ b/apps/client/src/components/ui/TermsAndPrivacyModal.jsx
@@ -106,16 +106,47 @@ const TermsAndPrivacyModal = ({ open, onAccept }) => {
           </Typography>
           <Typography variant="body2" color="text.secondary" paragraph>
             <strong>2. Колачиња (Cookies) и Local Storage:</strong> Ние
-            користиме технологии како Local Storage исклучиво за функционални
-            потреби на апликацијата (како на пример, зачувување на изборот за
-            темна/светла тема и памтење дека сте ги прифатиле овие услови), со
-            цел да ви овозможиме подобро корисничко искуство.
+            користиме Local Storage за функционални потреби (зачувување на
+            изборот за темна/светла тема и памтење дека сте ги прифатиле овие
+            услови). Покрај тоа, нашиот сервер поставува колаче{" "}
+            <strong>obrok_vid</strong> — анонимен, траен идентификатор за
+            посетители (важност: 1 година). Ова колаче е{" "}
+            <strong>httpOnly</strong> (не е достапно преку JavaScript) и{" "}
+            <strong>не содржи лични податоци</strong>. Се користи исклучиво за
+            следење на бројот на уникатни посети со цел подобрување на
+            апликацијата.{" "}
+            <em>
+              (In addition to Local Storage, our server sets an{" "}
+              <strong>obrok_vid</strong> httpOnly analytics cookie — a random
+              anonymous visitor identifier, valid for 1 year — used solely to
+              count unique visits.)
+            </em>
           </Typography>
           <Typography variant="body2" color="text.secondary" paragraph>
-            <strong>3. Аналитика:</strong> Може да собираме анонимизирани
-            податоци за посетеноста исклучиво со цел подобрување на стабилноста
-            на апликацијата. Не собираме податоци кои можат лично да ве
-            идентификуваат (PII).
+            <strong>3. Аналитика:</strong> Собираме технички податоци за
+            употребата на апликацијата со цел подобрување на нејзината
+            стабилност и перформанси. Конкретно:{" "}
+            <strong>
+              (а) прегледи на страници и навигациски настани; (б) сигнали за
+              активност на секои 60 секунди додека апликацијата е отворена; (в)
+              употреба на функциите за пребарување (паметно пребарување и
+              хибридно пребарување).
+            </strong>{" "}
+            За секоја сесија на посетители, серверот привремено зачувува{" "}
+            <strong>IP адреса</strong> и <strong>User-Agent</strong> ниска
+            исклучиво за безбедносни цели и проверка на исправноста на
+            системот. Суровите настани се бришат по <strong>90 дена</strong>;
+            месечни агрегирани статистики (само бројки, без лична идентификација)
+            се чуваат подолгорочно. Пристап до детални извештаи имаат само
+            администраторите.{" "}
+            <em>
+              (We collect page views, 60 s activity heartbeats, and
+              smart/hybrid-search usage events. Each visitor session temporarily
+              stores an IP address and User-Agent string for security and
+              reliability checks only. Raw events are deleted after 90 days;
+              anonymous monthly aggregates are retained longer. Detailed reports
+              are accessible only to administrators.)
+            </em>
           </Typography>
         </Box>
       </DialogContent>

--- a/apps/client/src/features/dashboard/components/DashboardLayout.jsx
+++ b/apps/client/src/features/dashboard/components/DashboardLayout.jsx
@@ -8,6 +8,7 @@ import StorefrontIcon from "@mui/icons-material/Storefront";
 import Inventory2Icon from "@mui/icons-material/Inventory2";
 import EventIcon from "@mui/icons-material/Event";
 import AssessmentIcon from "@mui/icons-material/Assessment";
+import InsightsIcon from "@mui/icons-material/Insights";
 import TuneIcon from "@mui/icons-material/Tune";
 
 const SECTIONS = [
@@ -16,6 +17,7 @@ const SECTIONS = [
   { label: "Products", path: "/dashboard/products", prefix: "/dashboard/product", icon: <Inventory2Icon /> },
   { label: "Holidays", path: "/dashboard/holidays", prefix: "/dashboard/holiday", icon: <EventIcon /> },
   { label: "Reports", path: "/dashboard/reporting", prefix: "/dashboard/reporting", icon: <AssessmentIcon /> },
+  { label: "Insights", path: "/dashboard/insights", prefix: "/dashboard/insights", icon: <InsightsIcon /> },
   { label: "Features", path: "/dashboard/features", prefix: "/dashboard/features", icon: <TuneIcon /> },
 ];
 

--- a/apps/client/src/features/insights/hooks/useInsightsQueries.js
+++ b/apps/client/src/features/insights/hooks/useInsightsQueries.js
@@ -1,0 +1,48 @@
+import { useQuery } from "@tanstack/react-query";
+import useAxiosPrivate from "@/hooks/useAxiosPrivate";
+
+export const insightsKeys = {
+  all: ["insights"],
+  summary: (days) => [...insightsKeys.all, "summary", days],
+  featureTrends: (days) => [...insightsKeys.all, "feature-trends", days],
+};
+
+export function useInsightsSummary(days = 30) {
+  const axiosPrivate = useAxiosPrivate();
+
+  return useQuery({
+    queryKey: insightsKeys.summary(days),
+    queryFn: async () => {
+      const res = await axiosPrivate.get(`/analytics/summary?days=${days}`);
+      return res.data;
+    },
+    enabled: !!days,
+  });
+}
+
+export function useInsightsFeatureTrends(days = 30) {
+  const axiosPrivate = useAxiosPrivate();
+
+  return useQuery({
+    queryKey: insightsKeys.featureTrends(days),
+    queryFn: async () => {
+      const res = await axiosPrivate.get(`/analytics/feature-trends?days=${days}`);
+      return res.data;
+    },
+    enabled: !!days,
+  });
+}
+
+export async function downloadInsightsCsv(axiosPrivate, days = 30) {
+  const res = await axiosPrivate.get(`/analytics/export?days=${days}`, {
+    responseType: "blob",
+  });
+  const url = window.URL.createObjectURL(new Blob([res.data]));
+  const link = document.createElement("a");
+  link.href = url;
+  link.setAttribute("download", `insights-${days}d.csv`);
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  window.URL.revokeObjectURL(url);
+}

--- a/apps/client/src/features/insights/hooks/useVisitorHeartbeat.js
+++ b/apps/client/src/features/insights/hooks/useVisitorHeartbeat.js
@@ -1,0 +1,48 @@
+import { useCallback, useEffect, useRef } from "react";
+import { useLocation } from "react-router-dom";
+import { axiosPublic } from "@/api/axios";
+
+const HEARTBEAT_INTERVAL_MS = 60 * 1000;
+
+export default function useVisitorHeartbeat() {
+  const { pathname } = useLocation();
+  const latestPathRef = useRef(pathname);
+
+  useEffect(() => {
+    latestPathRef.current = pathname;
+  }, [pathname]);
+
+  const sendHeartbeat = useCallback(async ({ path, isPageView = false }) => {
+    try {
+      await axiosPublic.post("/analytics/heartbeat", { path, isPageView });
+    } catch {
+      // Analytics should never block UX.
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!pathname) return;
+    sendHeartbeat({ path: pathname, isPageView: true });
+  }, [pathname, sendHeartbeat]);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      if (!document.hidden) {
+        sendHeartbeat({ path: latestPathRef.current || pathname || "/", isPageView: false });
+      }
+    }, HEARTBEAT_INTERVAL_MS);
+
+    const onVisibility = () => {
+      if (!document.hidden) {
+        sendHeartbeat({ path: latestPathRef.current || pathname || "/", isPageView: false });
+      }
+    };
+
+    document.addEventListener("visibilitychange", onVisibility);
+
+    return () => {
+      clearInterval(intervalId);
+      document.removeEventListener("visibilitychange", onVisibility);
+    };
+  }, [pathname, sendHeartbeat]);
+}

--- a/apps/client/src/features/insights/pages/InsightsPage.jsx
+++ b/apps/client/src/features/insights/pages/InsightsPage.jsx
@@ -1,0 +1,246 @@
+import React, { useMemo, useState } from "react";
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  FormControl,
+  Grid,
+  InputLabel,
+  MenuItem,
+  Select,
+  Skeleton,
+  Stack,
+  Typography,
+} from "@mui/material";
+import PeopleAltIcon from "@mui/icons-material/PeopleAlt";
+import VisibilityIcon from "@mui/icons-material/Visibility";
+import PsychologyIcon from "@mui/icons-material/Psychology";
+import BoltIcon from "@mui/icons-material/Bolt";
+import RadarIcon from "@mui/icons-material/Radar";
+import DownloadIcon from "@mui/icons-material/Download";
+import {
+  ResponsiveContainer,
+  LineChart,
+  Line,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  BarChart,
+  Bar,
+} from "recharts";
+import useAxiosPrivate from "@/hooks/useAxiosPrivate";
+import {
+  useInsightsSummary,
+  useInsightsFeatureTrends,
+  downloadInsightsCsv,
+} from "@/features/insights/hooks/useInsightsQueries";
+
+const RANGE_OPTIONS = [
+  { label: "Last 30 days", value: 30 },
+  { label: "Last 90 days", value: 90 },
+  { label: "Last 365 days", value: 365 },
+];
+
+const StatCard = ({ title, value, icon }) => (
+  <Card elevation={0} sx={{ border: 1, borderColor: "divider", borderRadius: 2, height: "100%" }}>
+    <CardContent>
+      <Stack direction="row" justifyContent="space-between" alignItems="center" mb={1}>
+        <Typography variant="body2" color="text.secondary">{title}</Typography>
+        {icon}
+      </Stack>
+      <Typography variant="h4" fontWeight={700}>{value}</Typography>
+    </CardContent>
+  </Card>
+);
+
+const ChartCard = ({ title, children }) => (
+  <Card elevation={0} sx={{ border: 1, borderColor: "divider", borderRadius: 2 }}>
+    <CardContent>
+      <Typography variant="subtitle1" fontWeight={700} sx={{ mb: 2 }}>{title}</Typography>
+      <Box sx={{ width: "100%", height: 320 }}>{children}</Box>
+    </CardContent>
+  </Card>
+);
+
+const InsightsPage = () => {
+  const [days, setDays] = useState(30);
+  const [exportError, setExportError] = useState("");
+  const axiosPrivate = useAxiosPrivate();
+  const { data, isLoading, isError, error } = useInsightsSummary(days);
+  const { data: featureTrendData } = useInsightsFeatureTrends(days);
+
+  const featureData = useMemo(() => ([
+    {
+      feature: "Smart Search",
+      count: data?.featureUsage?.["smart-search"] || 0,
+    },
+    {
+      feature: "Hybrid Search",
+      count: data?.featureUsage?.["hybrid-search"] || 0,
+    },
+  ]), [data]);
+
+  const handleExport = async () => {
+    setExportError("");
+    try {
+      await downloadInsightsCsv(axiosPrivate, days);
+    } catch (err) {
+      setExportError(err?.response?.data?.message || "Only admin users can export insights CSV.");
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <Box>
+        <Skeleton variant="text" width={240} height={42} sx={{ mb: 2 }} />
+        <Grid container spacing={2} sx={{ mb: 2 }}>
+          {Array.from({ length: 5 }).map((_, idx) => (
+            <Grid key={idx} size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+              <Skeleton variant="rounded" height={120} />
+            </Grid>
+          ))}
+        </Grid>
+        <Skeleton variant="rounded" height={340} sx={{ mb: 2 }} />
+        <Skeleton variant="rounded" height={340} sx={{ mb: 2 }} />
+      </Box>
+    );
+  }
+
+  if (isError) {
+    return (
+      <Alert severity="error">
+        {error?.response?.data?.message || "Failed to load insights statistics."}
+      </Alert>
+    );
+  }
+
+  return (
+    <Box>
+      <Stack
+        direction={{ xs: "column", sm: "row" }}
+        justifyContent="space-between"
+        alignItems={{ xs: "stretch", sm: "center" }}
+        spacing={2}
+        sx={{ mb: 2.5 }}
+      >
+        <Typography variant="h5" sx={{ fontWeight: 700 }}>Insights Statistics</Typography>
+        <Stack direction={{ xs: "column", sm: "row" }} spacing={1}>
+          <FormControl size="small" sx={{ minWidth: 180 }}>
+            <InputLabel id="insights-range-label">Range</InputLabel>
+            <Select
+              labelId="insights-range-label"
+              value={days}
+              label="Range"
+              onChange={(e) => setDays(Number(e.target.value))}
+            >
+              {RANGE_OPTIONS.map((option) => (
+                <MenuItem key={option.value} value={option.value}>{option.label}</MenuItem>
+              ))}
+            </Select>
+          </FormControl>
+          <Button
+            variant="outlined"
+            size="small"
+            startIcon={<DownloadIcon />}
+            onClick={handleExport}
+          >
+            Export CSV
+          </Button>
+        </Stack>
+      </Stack>
+
+      {exportError && (
+        <Alert severity="warning" sx={{ mb: 2 }}>{exportError}</Alert>
+      )}
+
+      <Grid container spacing={2} sx={{ mb: 2.5 }}>
+        <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+          <StatCard title="Total Visits" value={data?.totalVisits || 0} icon={<VisibilityIcon color="primary" />} />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+          <StatCard title="Unique Visitors" value={data?.uniqueVisitors || 0} icon={<PeopleAltIcon color="primary" />} />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 4, lg: 3 }}>
+          <StatCard title="Active Users (5m)" value={data?.activeUsersNow || 0} icon={<RadarIcon color="primary" />} />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 6, lg: 3 }}>
+          <StatCard title="Smart Search Uses" value={data?.featureUsage?.["smart-search"] || 0} icon={<PsychologyIcon color="primary" />} />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 6, lg: 3 }}>
+          <StatCard title="Hybrid Search Uses" value={data?.featureUsage?.["hybrid-search"] || 0} icon={<BoltIcon color="primary" />} />
+        </Grid>
+        <Grid size={{ xs: 12, sm: 6, md: 6, lg: 3 }}>
+          <StatCard title="Unique Visitors This Month" value={data?.currentMonthUniqueVisitors || 0} icon={<PeopleAltIcon color="primary" />} />
+        </Grid>
+      </Grid>
+
+      <Grid container spacing={2}>
+        <Grid size={{ xs: 12 }}>
+          <ChartCard title="Visits and Unique Visitors Over Time">
+            <ResponsiveContainer>
+              <LineChart data={data?.daily || []}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="day" tick={{ fontSize: 12 }} />
+                <YAxis allowDecimals={false} />
+                <Tooltip />
+                <Legend />
+                <Line type="monotone" dataKey="visits" stroke="#0B57D0" strokeWidth={2} dot={false} name="Visits" />
+                <Line type="monotone" dataKey="uniqueVisitors" stroke="#2E7D32" strokeWidth={2} dot={false} name="Unique Visitors" />
+              </LineChart>
+            </ResponsiveContainer>
+          </ChartCard>
+        </Grid>
+
+        <Grid size={{ xs: 12, md: 6 }}>
+          <ChartCard title="Feature Usage Trend (Daily)">
+            <ResponsiveContainer>
+              <LineChart data={featureTrendData?.daily || []}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="day" tick={{ fontSize: 12 }} />
+                <YAxis allowDecimals={false} />
+                <Tooltip />
+                <Legend />
+                <Line type="monotone" dataKey="smartSearch" stroke="#1E88E5" strokeWidth={2} dot={false} name="Smart Search" />
+                <Line type="monotone" dataKey="hybridSearch" stroke="#F4511E" strokeWidth={2} dot={false} name="Hybrid Search" />
+              </LineChart>
+            </ResponsiveContainer>
+          </ChartCard>
+        </Grid>
+
+        <Grid size={{ xs: 12, md: 6 }}>
+          <ChartCard title="Feature Usage Totals">
+            <ResponsiveContainer>
+              <BarChart data={featureData}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="feature" tick={{ fontSize: 12 }} />
+                <YAxis allowDecimals={false} />
+                <Tooltip />
+                <Bar dataKey="count" fill="#1565C0" radius={[6, 6, 0, 0]} />
+              </BarChart>
+            </ResponsiveContainer>
+          </ChartCard>
+        </Grid>
+
+        <Grid size={{ xs: 12 }}>
+          <ChartCard title="Monthly Unique Visitors">
+            <ResponsiveContainer>
+              <LineChart data={data?.monthlyUniqueVisitors || []}>
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="month" tick={{ fontSize: 12 }} />
+                <YAxis allowDecimals={false} />
+                <Tooltip />
+                <Line type="monotone" dataKey="uniqueVisitors" stroke="#00695C" strokeWidth={2} dot={false} name="Monthly Unique Visitors" />
+              </LineChart>
+            </ResponsiveContainer>
+          </ChartCard>
+        </Grid>
+      </Grid>
+    </Box>
+  );
+};
+
+export default InsightsPage;

--- a/apps/server/src/app.js
+++ b/apps/server/src/app.js
@@ -7,6 +7,7 @@ import helmet from "helmet";
 import credentials from "./modules/auth/middleware/credentials.js";
 import corsOptions from "./config/corsOptions.js";
 import { errorHandler } from "./shared/middleware/errorHandler.js";
+import visitorTracking from "./shared/middleware/visitorTracking.js";
 
 import { authRouter } from "./modules/auth/auth.routes.js";
 import { chainRouter } from "./modules/chain/chain.routes.js";
@@ -18,6 +19,7 @@ import { searchRouter } from "./modules/search/search.routes.js";
 import { smartSearchRouter } from "./modules/search/smart-search.routes.js";
 import { publicHolidayRouter } from "./modules/public-holiday/public-holiday.routes.js";
 import { reportRouter } from "./modules/report/report.routes.js";
+import { analyticsRouter } from "./modules/analytics/analytics.routes.js";
 
 const app = express();
 
@@ -32,6 +34,7 @@ app.use(cors(corsOptions));
 app.use(express.urlencoded({ limit: "10mb", extended: false }));
 app.use(express.json({ limit: "10mb" }));
 app.use(cookieParser());
+app.use(visitorTracking);
 app.use("/uploads", express.static(path.resolve("src/uploads")));
 
 app.use("/api", authRouter);
@@ -44,6 +47,7 @@ app.use("/api/search", searchRouter);
 app.use("/api/smart-search", smartSearchRouter);
 app.use("/api/public-holidays", publicHolidayRouter);
 app.use("/api/reports", reportRouter);
+app.use("/api/analytics", analyticsRouter);
 
 app.use(errorHandler);
 

--- a/apps/server/src/container.js
+++ b/apps/server/src/container.js
@@ -31,6 +31,9 @@ import { PublicHolidayController } from "./modules/public-holiday/public-holiday
 import { ReportJobRepository } from "./modules/report/report-job.repository.js";
 import { ReportService } from "./modules/report/report.service.js";
 import { ReportController } from "./modules/report/report.controller.js";
+import { AnalyticsRepository } from "./modules/analytics/analytics.repository.js";
+import { AnalyticsService } from "./modules/analytics/analytics.service.js";
+import { AnalyticsController } from "./modules/analytics/analytics.controller.js";
 
 import { AuthController } from "./modules/auth/auth.controller.js";
 import { ImageController } from "./modules/image/image.controller.js";
@@ -75,6 +78,8 @@ const geocoderService = new GeocoderService();
 const featureFlagService = new FeatureFlagService(featureFlagRepository);
 const embeddingService = new EmbeddingService();
 const productEmbeddingRepository = new ProductEmbeddingRepository();
+const analyticsRepository = new AnalyticsRepository();
+const analyticsService = new AnalyticsService(analyticsRepository);
 
 const intentParserService = new IntentParserService();
 
@@ -83,6 +88,7 @@ const searchService = new SearchService(
   productEmbeddingRepository,
   featureFlagService,
   intentParserService,
+  analyticsService,
 );
 
 const publicHolidayRepository = new PublicHolidayRepository();
@@ -96,6 +102,7 @@ const smartSearchService = new SmartSearchService(
   searchService,
   featureFlagService,
   publicHolidayService,
+  analyticsService,
 );
 
 export const scraperService = new ScraperService(
@@ -120,4 +127,11 @@ export const searchController = new SearchController(searchService);
 export const smartSearchController = new SmartSearchController(smartSearchService);
 export const publicHolidayController = new PublicHolidayController(publicHolidayService);
 export const reportController = new ReportController(reportService);
-export { featureFlagService, embeddingService, productEmbeddingRepository, marketProductRepository };
+export const analyticsController = new AnalyticsController(analyticsService);
+export {
+  featureFlagService,
+  embeddingService,
+  productEmbeddingRepository,
+  marketProductRepository,
+  analyticsService,
+};

--- a/apps/server/src/modules/analytics/analytics.controller.js
+++ b/apps/server/src/modules/analytics/analytics.controller.js
@@ -1,0 +1,42 @@
+export class AnalyticsController {
+  constructor(analyticsService) {
+    this.analyticsService = analyticsService;
+  }
+
+  heartbeat = async (req, res) => {
+    const result = await this.analyticsService.trackHeartbeat({
+      visitorId: req.visitorId,
+      userId: req.user || null,
+      path: req.body?.path || req.path,
+      isPageView: req.body?.isPageView === true,
+      ip: req.ip,
+      userAgent: req.headers["user-agent"] || null,
+    });
+
+    res.status(200).json(result);
+  };
+
+  summary = async (req, res) => {
+    const days = req.query.days ? Number(req.query.days) : 30;
+    const result = await this.analyticsService.getSummary({ days, activeWindowMinutes: 5 });
+    res.status(200).json(result);
+  };
+
+  featureTrends = async (req, res) => {
+    const days = req.query.days ? Number(req.query.days) : 30;
+    const result = await this.analyticsService.getFeatureUsageTrend({ days });
+    res.status(200).json(result);
+  };
+
+  exportCsv = async (req, res) => {
+    const days = req.query.days ? Number(req.query.days) : 30;
+    const { csv, fileName } = await this.analyticsService.exportSummaryCsv({
+      days,
+      activeWindowMinutes: 5,
+    });
+
+    res.setHeader("Content-Type", "text/csv");
+    res.setHeader("Content-Disposition", `attachment; filename=${fileName}`);
+    res.status(200).send(csv);
+  };
+}

--- a/apps/server/src/modules/analytics/analytics.cron.js
+++ b/apps/server/src/modules/analytics/analytics.cron.js
@@ -1,0 +1,20 @@
+import cron from "node-cron";
+
+export const startAnalyticsCron = (analyticsService) => {
+  const retentionDays = Number(process.env.ANALYTICS_RAW_RETENTION_DAYS || 90);
+
+  cron.schedule("30 2 * * *", async () => {
+    try {
+      const result = await analyticsService.cleanupRawEvents({ retentionDays });
+      console.log(
+        `[AnalyticsCron] Cleanup complete (retention=${retentionDays}d): events=${result.eventsDeleted}, sessions=${result.sessionsDeleted}`,
+      );
+    } catch (err) {
+      console.error("[AnalyticsCron] Cleanup failed:", err.message);
+    }
+  });
+
+  console.log(
+    `[AnalyticsCron] Scheduled daily cleanup at 02:30 (raw retention ${retentionDays} days).`,
+  );
+};

--- a/apps/server/src/modules/analytics/analytics.model.js
+++ b/apps/server/src/modules/analytics/analytics.model.js
@@ -1,0 +1,65 @@
+import mongoose from "mongoose";
+
+export const AnalyticsEventType = {
+  PAGE_VIEW: "page_view",
+  HEARTBEAT: "heartbeat",
+  FEATURE_USAGE: "feature_usage",
+};
+
+const analyticsEventSchema = new mongoose.Schema(
+  {
+    visitorId: { type: String, required: true, index: true },
+    userId: { type: String, default: null, index: true },
+    identityKey: { type: String, required: true, index: true },
+    eventType: {
+      type: String,
+      enum: Object.values(AnalyticsEventType),
+      required: true,
+      index: true,
+    },
+    feature: { type: String, default: null, index: true },
+    path: { type: String, default: null },
+    metadata: { type: mongoose.Schema.Types.Mixed, default: null },
+    occurredAt: { type: Date, default: Date.now, index: true },
+  },
+  { timestamps: true },
+);
+
+analyticsEventSchema.index({ occurredAt: 1, eventType: 1 });
+analyticsEventSchema.index({ eventType: 1, feature: 1, occurredAt: 1 });
+analyticsEventSchema.index({ occurredAt: 1, identityKey: 1 });
+
+const visitorSessionSchema = new mongoose.Schema(
+  {
+    visitorId: { type: String, required: true, unique: true, index: true },
+    userId: { type: String, default: null, index: true },
+    firstSeenAt: { type: Date, default: Date.now },
+    lastSeenAt: { type: Date, default: Date.now, index: true },
+    lastPath: { type: String, default: null },
+    ip: { type: String, default: null },
+    userAgent: { type: String, default: null },
+  },
+  { timestamps: true },
+);
+
+visitorSessionSchema.index({ lastSeenAt: 1 });
+
+const analyticsMonthlyAggregateSchema = new mongoose.Schema(
+  {
+    month: { type: String, required: true, unique: true, index: true },
+    monthStart: { type: Date, required: true, index: true },
+    monthEnd: { type: Date, required: true },
+    visits: { type: Number, default: 0 },
+    uniqueVisitors: { type: Number, default: 0 },
+    smartSearchUses: { type: Number, default: 0 },
+    hybridSearchUses: { type: Number, default: 0 },
+    source: { type: String, default: "raw-events" },
+  },
+  { timestamps: true },
+);
+
+analyticsMonthlyAggregateSchema.index({ monthStart: 1 });
+
+export const AnalyticsEventModel = mongoose.model("AnalyticsEvent", analyticsEventSchema);
+export const VisitorSessionModel = mongoose.model("VisitorSession", visitorSessionSchema);
+export const AnalyticsMonthlyAggregateModel = mongoose.model("AnalyticsMonthlyAggregate", analyticsMonthlyAggregateSchema);

--- a/apps/server/src/modules/analytics/analytics.repository.js
+++ b/apps/server/src/modules/analytics/analytics.repository.js
@@ -1,0 +1,341 @@
+import {
+  AnalyticsEventModel,
+  AnalyticsEventType,
+  VisitorSessionModel,
+  AnalyticsMonthlyAggregateModel,
+} from "./analytics.model.js";
+
+export class AnalyticsRepository {
+  #monthKey(date) {
+    return date.toISOString().slice(0, 7);
+  }
+
+  #monthRange(date) {
+    const monthStart = new Date(date.getFullYear(), date.getMonth(), 1);
+    const monthEnd = new Date(date.getFullYear(), date.getMonth() + 1, 1);
+    return { monthStart, monthEnd };
+  }
+
+  async upsertVisitorSession({ visitorId, userId, path, ip, userAgent, seenAt }) {
+    return VisitorSessionModel.findOneAndUpdate(
+      { visitorId },
+      {
+        $set: {
+          userId: userId || null,
+          lastSeenAt: seenAt,
+          lastPath: path || null,
+          ip: ip || null,
+          userAgent: userAgent || null,
+        },
+        $setOnInsert: { firstSeenAt: seenAt },
+      },
+      { upsert: true, new: true },
+    ).exec();
+  }
+
+  async createEvent(event) {
+    return AnalyticsEventModel.create(event);
+  }
+
+  async getFeatureUsageTrend({ from, to }) {
+    return AnalyticsEventModel.aggregate([
+      {
+        $match: {
+          occurredAt: { $gte: from, $lte: to },
+          eventType: AnalyticsEventType.FEATURE_USAGE,
+          feature: { $in: ["smart-search", "hybrid-search"] },
+        },
+      },
+      {
+        $group: {
+          _id: {
+            day: {
+              $dateToString: {
+                format: "%Y-%m-%d",
+                date: "$occurredAt",
+              },
+            },
+            feature: "$feature",
+          },
+          count: { $sum: 1 },
+        },
+      },
+      {
+        $group: {
+          _id: "$_id.day",
+          smartSearch: {
+            $sum: {
+              $cond: [{ $eq: ["$_id.feature", "smart-search"] }, "$count", 0],
+            },
+          },
+          hybridSearch: {
+            $sum: {
+              $cond: [{ $eq: ["$_id.feature", "hybrid-search"] }, "$count", 0],
+            },
+          },
+        },
+      },
+      {
+        $project: {
+          _id: 0,
+          day: "$_id",
+          smartSearch: 1,
+          hybridSearch: 1,
+        },
+      },
+      { $sort: { day: 1 } },
+    ]);
+  }
+
+  async getSummary({ from, to, activeWindowMinutes }) {
+    const visitDateFilter = {
+      occurredAt: { $gte: from, $lte: to },
+      eventType: AnalyticsEventType.PAGE_VIEW,
+    };
+
+    const currentMonthStart = new Date(to.getFullYear(), to.getMonth(), 1);
+    const currentMonthVisitsFilter = {
+      occurredAt: { $gte: currentMonthStart, $lte: to },
+      eventType: AnalyticsEventType.PAGE_VIEW,
+    };
+
+    const [
+      totalVisits,
+      uniqueVisitorsRows,
+      currentMonthUniqueRows,
+      monthlyRowsRaw,
+      monthlyRowsArchived,
+      dailyRows,
+      featureTotals,
+      featureUsageDaily,
+      activeNow,
+    ] =
+      await Promise.all([
+        AnalyticsEventModel.countDocuments(visitDateFilter),
+        AnalyticsEventModel.aggregate([
+          { $match: visitDateFilter },
+          { $group: { _id: "$identityKey" } },
+          { $count: "count" },
+        ]),
+        AnalyticsEventModel.aggregate([
+          { $match: currentMonthVisitsFilter },
+          { $group: { _id: "$identityKey" } },
+          { $count: "count" },
+        ]),
+        AnalyticsEventModel.aggregate([
+          {
+            $match: {
+              monthStart: { $gte: from, $lte: to },
+            },
+          },
+          {
+            $project: {
+              _id: 0,
+              month: 1,
+              uniqueVisitors: 1,
+            },
+          },
+          { $sort: { month: 1 } },
+        ]),
+        AnalyticsEventModel.aggregate([
+          { $match: visitDateFilter },
+          {
+            $group: {
+              _id: {
+                month: {
+                  $dateToString: {
+                    format: "%Y-%m",
+                    date: "$occurredAt",
+                  },
+                },
+              },
+              visitors: { $addToSet: "$identityKey" },
+            },
+          },
+          {
+            $project: {
+              _id: 0,
+              month: "$_id.month",
+              uniqueVisitors: { $size: "$visitors" },
+            },
+          },
+          { $sort: { month: 1 } },
+        ]),
+        AnalyticsEventModel.aggregate([
+          { $match: visitDateFilter },
+          {
+            $group: {
+              _id: {
+                day: {
+                  $dateToString: {
+                    format: "%Y-%m-%d",
+                    date: "$occurredAt",
+                  },
+                },
+              },
+              visits: {
+                $sum: {
+                  $cond: [{ $eq: ["$eventType", AnalyticsEventType.PAGE_VIEW] }, 1, 0],
+                },
+              },
+              visitors: { $addToSet: "$identityKey" },
+            },
+          },
+          {
+            $project: {
+              _id: 0,
+              day: "$_id.day",
+              visits: 1,
+              uniqueVisitors: { $size: "$visitors" },
+            },
+          },
+          { $sort: { day: 1 } },
+        ]),
+        AnalyticsEventModel.aggregate([
+          {
+            $match: {
+              occurredAt: { $gte: from, $lte: to },
+              eventType: AnalyticsEventType.FEATURE_USAGE,
+              feature: { $in: ["smart-search", "hybrid-search"] },
+            },
+          },
+          { $group: { _id: "$feature", count: { $sum: 1 } } },
+        ]),
+        this.getFeatureUsageTrend({ from, to }),
+        VisitorSessionModel.countDocuments({
+          lastSeenAt: {
+            $gte: new Date(Date.now() - activeWindowMinutes * 60 * 1000),
+          },
+        }),
+      ]);
+
+    const usage = {
+      "smart-search": 0,
+      "hybrid-search": 0,
+    };
+
+    featureTotals.forEach((row) => {
+      usage[row._id] = row.count;
+    });
+
+    const monthlyMap = new Map();
+    monthlyRowsArchived.forEach((row) => {
+      monthlyMap.set(row.month, row.uniqueVisitors);
+    });
+    monthlyRowsRaw.forEach((row) => {
+      monthlyMap.set(row.month, row.uniqueVisitors);
+    });
+
+    const monthlyUniqueVisitors = Array.from(monthlyMap.entries())
+      .map(([month, uniqueVisitors]) => ({ month, uniqueVisitors }))
+      .sort((a, b) => a.month.localeCompare(b.month));
+
+    return {
+      totalVisits,
+      uniqueVisitors: uniqueVisitorsRows[0]?.count || 0,
+      currentMonthUniqueVisitors: currentMonthUniqueRows[0]?.count || 0,
+      activeUsersNow: activeNow,
+      featureUsage: usage,
+      featureUsageDaily,
+      monthlyUniqueVisitors,
+      daily: dailyRows,
+    };
+  }
+
+  async archiveMonthFromRaw(monthDate) {
+    const { monthStart, monthEnd } = this.#monthRange(monthDate);
+    const month = this.#monthKey(monthStart);
+
+    const [visits, uniqueRows, featureRows] = await Promise.all([
+      AnalyticsEventModel.countDocuments({
+        occurredAt: { $gte: monthStart, $lt: monthEnd },
+        eventType: AnalyticsEventType.PAGE_VIEW,
+      }),
+      AnalyticsEventModel.aggregate([
+        {
+          $match: {
+            occurredAt: { $gte: monthStart, $lt: monthEnd },
+            eventType: AnalyticsEventType.PAGE_VIEW,
+          },
+        },
+        { $group: { _id: "$identityKey" } },
+        { $count: "count" },
+      ]),
+      AnalyticsEventModel.aggregate([
+        {
+          $match: {
+            occurredAt: { $gte: monthStart, $lt: monthEnd },
+            eventType: AnalyticsEventType.FEATURE_USAGE,
+            feature: { $in: ["smart-search", "hybrid-search"] },
+          },
+        },
+        { $group: { _id: "$feature", count: { $sum: 1 } } },
+      ]),
+    ]);
+
+    const featureMap = {
+      "smart-search": 0,
+      "hybrid-search": 0,
+    };
+    featureRows.forEach((row) => {
+      featureMap[row._id] = row.count;
+    });
+
+    await AnalyticsMonthlyAggregateModel.findOneAndUpdate(
+      { month },
+      {
+        $set: {
+          month,
+          monthStart,
+          monthEnd,
+          visits,
+          uniqueVisitors: uniqueRows[0]?.count || 0,
+          smartSearchUses: featureMap["smart-search"],
+          hybridSearchUses: featureMap["hybrid-search"],
+          source: "raw-events",
+        },
+      },
+      { upsert: true, new: true },
+    ).exec();
+  }
+
+  async archiveMonthsBefore(cutoffMonthStart) {
+    const months = await AnalyticsEventModel.aggregate([
+      {
+        $match: {
+          occurredAt: { $lt: cutoffMonthStart },
+        },
+      },
+      {
+        $group: {
+          _id: {
+            year: { $year: "$occurredAt" },
+            month: { $month: "$occurredAt" },
+          },
+        },
+      },
+      { $sort: { "_id.year": 1, "_id.month": 1 } },
+    ]);
+
+    for (const row of months) {
+      const monthDate = new Date(row._id.year, row._id.month - 1, 1);
+      await this.archiveMonthFromRaw(monthDate);
+    }
+
+    return months.length;
+  }
+
+  async cleanupRawEventsOlderThan(cutoffDate) {
+    const result = await AnalyticsEventModel.deleteMany({
+      occurredAt: { $lt: cutoffDate },
+    });
+    return result.deletedCount || 0;
+  }
+
+  async cleanupStaleVisitorSessionsOlderThan(cutoffDate) {
+    const result = await VisitorSessionModel.deleteMany({
+      lastSeenAt: { $lt: cutoffDate },
+    });
+    return result.deletedCount || 0;
+  }
+}

--- a/apps/server/src/modules/analytics/analytics.routes.js
+++ b/apps/server/src/modules/analytics/analytics.routes.js
@@ -1,0 +1,45 @@
+import { Router } from "express";
+import { analyticsController } from "../../container.js";
+import verifyJWT from "../auth/middleware/verifyJWT.js";
+import optionalVerifyJWT from "../auth/middleware/optionalVerifyJWT.js";
+import verifyAdminUser from "../auth/middleware/verifyAdminUser.js";
+import { validateRequest } from "../../shared/middleware/validateRequest.js";
+import {
+  analyticsHeartbeatSchema,
+  analyticsSummaryQuerySchema,
+  analyticsFeatureTrendQuerySchema,
+  analyticsExportQuerySchema,
+} from "./analytics.schema.js";
+
+const router = Router();
+
+router.post(
+  "/heartbeat",
+  optionalVerifyJWT,
+  validateRequest(analyticsHeartbeatSchema),
+  analyticsController.heartbeat,
+);
+
+router.get(
+  "/summary",
+  verifyJWT,
+  validateRequest(analyticsSummaryQuerySchema, "query"),
+  analyticsController.summary,
+);
+
+router.get(
+  "/feature-trends",
+  verifyJWT,
+  validateRequest(analyticsFeatureTrendQuerySchema, "query"),
+  analyticsController.featureTrends,
+);
+
+router.get(
+  "/export",
+  verifyJWT,
+  verifyAdminUser,
+  validateRequest(analyticsExportQuerySchema, "query"),
+  analyticsController.exportCsv,
+);
+
+export { router as analyticsRouter };

--- a/apps/server/src/modules/analytics/analytics.schema.js
+++ b/apps/server/src/modules/analytics/analytics.schema.js
@@ -1,0 +1,18 @@
+import { z } from "zod";
+
+export const analyticsHeartbeatSchema = z.object({
+  path: z.string().trim().max(2048).optional().nullable(),
+  isPageView: z.boolean().optional(),
+});
+
+export const analyticsSummaryQuerySchema = z.object({
+  days: z.coerce.number().int().min(7).max(365).optional(),
+});
+
+export const analyticsFeatureTrendQuerySchema = z.object({
+  days: z.coerce.number().int().min(7).max(365).optional(),
+});
+
+export const analyticsExportQuerySchema = z.object({
+  days: z.coerce.number().int().min(7).max(365).optional(),
+});

--- a/apps/server/src/modules/analytics/analytics.service.js
+++ b/apps/server/src/modules/analytics/analytics.service.js
@@ -1,0 +1,159 @@
+import { AnalyticsEventType } from "./analytics.model.js";
+import { Parser } from "@json2csv/plainjs";
+
+export class AnalyticsService {
+  constructor(analyticsRepository) {
+    this.analyticsRepository = analyticsRepository;
+  }
+
+  #identityKey(visitorId, userId) {
+    return userId ? `user:${userId}` : `visitor:${visitorId}`;
+  }
+
+  async trackHeartbeat({ visitorId, userId, path, isPageView = false, ip, userAgent }) {
+    const seenAt = new Date();
+    const identityKey = this.#identityKey(visitorId, userId);
+
+    await this.analyticsRepository.upsertVisitorSession({
+      visitorId,
+      userId,
+      path,
+      ip,
+      userAgent,
+      seenAt,
+    });
+
+    await this.analyticsRepository.createEvent({
+      visitorId,
+      userId: userId || null,
+      identityKey,
+      eventType: AnalyticsEventType.HEARTBEAT,
+      path: path || null,
+      occurredAt: seenAt,
+    });
+
+    // Count visits only on route/page transitions, not every keepalive ping.
+    if (isPageView && path) {
+      await this.analyticsRepository.createEvent({
+        visitorId,
+        userId: userId || null,
+        identityKey,
+        eventType: AnalyticsEventType.PAGE_VIEW,
+        path,
+        occurredAt: seenAt,
+      });
+    }
+
+    return { ok: true };
+  }
+
+  async trackFeatureUsage({ visitorId, userId, feature, path }) {
+    if (!visitorId || !feature) return;
+
+    await this.analyticsRepository.createEvent({
+      visitorId,
+      userId: userId || null,
+      identityKey: this.#identityKey(visitorId, userId),
+      eventType: AnalyticsEventType.FEATURE_USAGE,
+      feature,
+      path: path || null,
+      occurredAt: new Date(),
+    });
+  }
+
+  async getSummary({ days = 30, activeWindowMinutes = 5 }) {
+    const to = new Date();
+    const from = new Date();
+    from.setDate(to.getDate() - days + 1);
+    from.setHours(0, 0, 0, 0);
+
+    const summary = await this.analyticsRepository.getSummary({
+      from,
+      to,
+      activeWindowMinutes,
+    });
+
+    return {
+      range: {
+        from,
+        to,
+        days,
+      },
+      ...summary,
+    };
+  }
+
+  async getFeatureUsageTrend({ days = 30 }) {
+    const to = new Date();
+    const from = new Date();
+    from.setDate(to.getDate() - days + 1);
+    from.setHours(0, 0, 0, 0);
+
+    const daily = await this.analyticsRepository.getFeatureUsageTrend({ from, to });
+
+    return {
+      range: { from, to, days },
+      daily,
+    };
+  }
+
+  async exportSummaryCsv({ days = 30, activeWindowMinutes = 5 }) {
+    const summary = await this.getSummary({ days, activeWindowMinutes });
+
+    const dailyMap = new Map(summary.daily.map((row) => [row.day, row]));
+    const featureMap = new Map(summary.featureUsageDaily.map((row) => [row.day, row]));
+    const allDays = new Set([...dailyMap.keys(), ...featureMap.keys()]);
+
+    const rows = Array.from(allDays)
+      .sort()
+      .map((day) => ({
+        day,
+        visits: dailyMap.get(day)?.visits || 0,
+        uniqueVisitors: dailyMap.get(day)?.uniqueVisitors || 0,
+        smartSearchUses: featureMap.get(day)?.smartSearch || 0,
+        hybridSearchUses: featureMap.get(day)?.hybridSearch || 0,
+      }));
+
+    const parser = new Parser({
+      fields: ["day", "visits", "uniqueVisitors", "smartSearchUses", "hybridSearchUses"],
+    });
+
+    const csv = parser.parse(rows.length ? rows : [
+      {
+        day: "",
+        visits: 0,
+        uniqueVisitors: 0,
+        smartSearchUses: 0,
+        hybridSearchUses: 0,
+      },
+    ]);
+
+    return {
+      fileName: `insights-${summary.range.from.toISOString().slice(0, 10)}-to-${summary.range.to.toISOString().slice(0, 10)}.csv`,
+      csv,
+      summary,
+    };
+  }
+
+  async cleanupRawEvents({ retentionDays = 90 }) {
+    const now = new Date();
+    const cutoffDate = new Date(now.getTime() - retentionDays * 24 * 60 * 60 * 1000);
+    const cutoffMonthStart = new Date(cutoffDate.getFullYear(), cutoffDate.getMonth(), 1);
+
+    const archivedMonths = await this.analyticsRepository.archiveMonthsBefore(cutoffMonthStart);
+
+    const [eventsDeleted, sessionsDeleted] = await Promise.all([
+      this.analyticsRepository.cleanupRawEventsOlderThan(cutoffMonthStart),
+      this.analyticsRepository.cleanupStaleVisitorSessionsOlderThan(cutoffDate),
+    ]);
+
+    return {
+      cutoffDate,
+      cutoffMonthStart,
+      retentionDays,
+      archivedMonths,
+      eventsDeleted,
+      sessionsDeleted,
+    };
+  }
+}

--- a/apps/server/src/modules/auth/middleware/optionalVerifyJWT.js
+++ b/apps/server/src/modules/auth/middleware/optionalVerifyJWT.js
@@ -1,0 +1,20 @@
+import jwt from "jsonwebtoken";
+
+const optionalVerifyJWT = (req, res, next) => {
+  const authHeader = req.headers.authorization || req.headers.Authorization;
+
+  if (!authHeader?.startsWith("Bearer ")) {
+    return next();
+  }
+
+  const token = authHeader.split(" ")[1];
+
+  jwt.verify(token, process.env.ACCESS_TOKEN_SECRET, (err, decoded) => {
+    if (!err) {
+      req.user = decoded.UserInfo.username;
+    }
+    next();
+  });
+};
+
+export default optionalVerifyJWT;

--- a/apps/server/src/modules/auth/middleware/verifyAdminUser.js
+++ b/apps/server/src/modules/auth/middleware/verifyAdminUser.js
@@ -1,0 +1,17 @@
+import { AppError } from "../../../shared/errors/AppError.js";
+
+const verifyAdminUser = (req, res, next) => {
+  const adminUsername = process.env.ADMIN_USERNAME;
+
+  if (!adminUsername) {
+    throw new AppError("Admin configuration is missing.", 500);
+  }
+
+  if (req.user !== adminUsername) {
+    throw new AppError("Forbidden.", 403);
+  }
+
+  next();
+};
+
+export default verifyAdminUser;

--- a/apps/server/src/modules/search/search.controller.js
+++ b/apps/server/src/modules/search/search.controller.js
@@ -4,7 +4,14 @@ export class SearchController {
   }
 
   search = async (req, res) => {
-    const result = await this.searchService.search(req.query);
+    const result = await this.searchService.search({
+      ...req.query,
+      analytics: {
+        visitorId: req.visitorId,
+        userId: req.user || null,
+        path: req.originalUrl,
+      },
+    });
     res.status(200).json(result);
   };
 }

--- a/apps/server/src/modules/search/search.routes.js
+++ b/apps/server/src/modules/search/search.routes.js
@@ -2,11 +2,13 @@ import { Router } from "express";
 import { searchController } from "../../container.js";
 import { validateRequest } from "../../shared/middleware/validateRequest.js";
 import { searchQuerySchema } from "./search.schema.js";
+import optionalVerifyJWT from "../auth/middleware/optionalVerifyJWT.js";
 
 const router = Router();
 
 router.get(
   "/",
+  optionalVerifyJWT,
   validateRequest(searchQuerySchema, "query"),
   searchController.search,
 );

--- a/apps/server/src/modules/search/search.service.js
+++ b/apps/server/src/modules/search/search.service.js
@@ -40,14 +40,16 @@ export class SearchService {
     productEmbeddingRepository,
     featureFlagService,
     intentParserService,
+    analyticsService = null,
   ) {
     this.embeddingService = embeddingService;
     this.productEmbeddingRepository = productEmbeddingRepository;
     this.featureFlagService = featureFlagService;
     this.intentParserService = intentParserService;
+    this.analyticsService = analyticsService;
   }
 
-  async search({ q, marketId, page = 1, limit = 10 }) {
+  async search({ q, marketId, page = 1, limit = 10, analytics = null }) {
     const isEnabled = await this.featureFlagService.isEnabled("ai-search");
     if (!isEnabled) {
       return { data: [], pagination: buildPaginationMeta({ total: 0, page, limit }), priceSort: null };
@@ -59,6 +61,13 @@ export class SearchService {
       : { searchTerms: q, priceSort: null, intent: "search", products: [] };
 
     const searchQuery = intent.searchTerms || q;
+
+    await this.analyticsService?.trackFeatureUsage({
+      visitorId: analytics?.visitorId,
+      userId: analytics?.userId,
+      feature: "hybrid-search",
+      path: analytics?.path,
+    });
 
     const [vectorResults, keywordResults] = await Promise.all([
       this.#vectorSearch(searchQuery, marketId),

--- a/apps/server/src/modules/search/smart-search.controller.js
+++ b/apps/server/src/modules/search/smart-search.controller.js
@@ -9,7 +9,14 @@ export class SmartSearchController {
   };
 
   search = async (req, res) => {
-    const result = await this.smartSearchService.search(req.query);
+    const result = await this.smartSearchService.search({
+      ...req.query,
+      analytics: {
+        visitorId: req.visitorId,
+        userId: req.user || null,
+        path: req.originalUrl,
+      },
+    });
     res.status(200).json(result);
   };
 }

--- a/apps/server/src/modules/search/smart-search.routes.js
+++ b/apps/server/src/modules/search/smart-search.routes.js
@@ -1,6 +1,7 @@
 import { Router } from "express";
 import { smartSearchController } from "../../container.js";
 import { validateRequest } from "../../shared/middleware/validateRequest.js";
+import optionalVerifyJWT from "../auth/middleware/optionalVerifyJWT.js";
 import {
   smartSearchQuerySchema,
   smartSearchBudgetQuerySchema,
@@ -10,12 +11,14 @@ const router = Router();
 
 router.get(
   "/budget",
+  optionalVerifyJWT,
   validateRequest(smartSearchBudgetQuerySchema, "query"),
   smartSearchController.getBudget,
 );
 
 router.get(
   "/",
+  optionalVerifyJWT,
   validateRequest(smartSearchQuerySchema, "query"),
   smartSearchController.search,
 );

--- a/apps/server/src/modules/search/smart-search.service.js
+++ b/apps/server/src/modules/search/smart-search.service.js
@@ -2,11 +2,12 @@ import { haversineDistance } from "../../shared/utils/haversine.js";
 import { calculateWeeklyBudget } from "../../shared/utils/obrokBudget.js";
 
 export class SmartSearchService {
-  constructor(intentParserService, searchService, featureFlagService, publicHolidayService) {
+  constructor(intentParserService, searchService, featureFlagService, publicHolidayService, analyticsService = null) {
     this.intentParserService = intentParserService;
     this.searchService = searchService;
     this.featureFlagService = featureFlagService;
     this.publicHolidayService = publicHolidayService;
+    this.analyticsService = analyticsService;
   }
 
   async getBudget() {
@@ -23,11 +24,18 @@ export class SmartSearchService {
     };
   }
 
-  async search({ q, lat, lon, budgetOnly }) {
+  async search({ q, lat, lon, budgetOnly, analytics = null }) {
     const isEnabled = await this.featureFlagService.isEnabled("smart-search");
     if (!isEnabled) {
       return { data: null, error: "Smart search is not enabled." };
     }
+
+    await this.analyticsService?.trackFeatureUsage({
+      visitorId: analytics?.visitorId,
+      userId: analytics?.userId,
+      feature: "smart-search",
+      path: analytics?.path,
+    });
 
     if (!this.intentParserService.isAvailable()) {
       return { data: null, error: "AI service is not configured." };

--- a/apps/server/src/server.js
+++ b/apps/server/src/server.js
@@ -3,9 +3,10 @@ import app from "./app.js";
 import connectDB from "./infrastructure/database/connectDB.js";
 import mongoose from "mongoose";
 import { startScraperCron } from "./modules/scraper/scraper.cron.js";
+import { startAnalyticsCron } from "./modules/analytics/analytics.cron.js";
 import { seedChainImages } from "./infrastructure/database/seed-chain-images.js";
 import { seedFeatureFlags } from "./infrastructure/database/seed-feature-flags.js";
-import { scraperService } from "./container.js";
+import { scraperService, analyticsService } from "./container.js";
 
 const PORT = process.env.PORT || 5000;
 
@@ -16,5 +17,6 @@ mongoose.connection.once("open", async () => {
   await seedChainImages();
   await seedFeatureFlags();
   startScraperCron(scraperService);
+  startAnalyticsCron(analyticsService);
   app.listen(PORT, () => console.log(`Server running on port ${PORT}`));
 });

--- a/apps/server/src/shared/middleware/visitorTracking.js
+++ b/apps/server/src/shared/middleware/visitorTracking.js
@@ -1,0 +1,26 @@
+import { randomUUID } from "crypto";
+
+const VISITOR_COOKIE = "obrok_vid";
+const COOKIE_MAX_AGE_MS = 1000 * 60 * 60 * 24 * 365;
+
+const isLikelyValidVisitorId = (value) =>
+  typeof value === "string" && value.length >= 12 && value.length <= 64;
+
+const visitorTracking = (req, res, next) => {
+  const existing = req.cookies?.[VISITOR_COOKIE];
+  const visitorId = isLikelyValidVisitorId(existing) ? existing : randomUUID();
+
+  if (!existing || existing !== visitorId) {
+    res.cookie(VISITOR_COOKIE, visitorId, {
+      httpOnly: true,
+      sameSite: "lax",
+      secure: process.env.NODE_ENV === "production",
+      maxAge: COOKIE_MAX_AGE_MS,
+    });
+  }
+
+  req.visitorId = visitorId;
+  next();
+};
+
+export default visitorTracking;


### PR DESCRIPTION
## Overview

Adds a full end-to-end analytics and insights platform — cookie-based visitor tracking, server-side event storage, a new admin Insights dashboard with charts and CSV export, and a compliant privacy policy update.

## Changes

### Consent Gate (`46fb4f4`)
- Extracted `ConsentGate` component from `entry.jsx`; app does not mount until the user accepts the Terms & Privacy modal

### Analytics Backend (`3d7c695`)
- **Visitor tracking middleware** — sets `obrok_vid` httpOnly cookie (1 year) on every request; provides anonymous visitor identity without login
- **Optional JWT middleware** — attaches authenticated user identity to analytics context when a valid token is present, without blocking unauthenticated requests
- **Admin guard middleware** — restricts sensitive routes to the configured `ADMIN_USERNAME`
- **Analytics module** (`model` / `repository` / `service` / `controller` / `routes` / `schema`):
  - Three Mongoose models: `AnalyticsEvent`, `VisitorSession`, `AnalyticsMonthlyAggregate`
  - Event types: `page_view`, `heartbeat`, `feature_usage`
  - Endpoints:
    - `POST /api/analytics/heartbeat` — page-view and keepalive pings (optional JWT)
    - `GET /api/analytics/summary` — KPI summary including monthly unique visitors (requires auth)
    - `GET /api/analytics/feature-trends` — per-day smart-search / hybrid-search usage (requires auth)
    - `GET /api/analytics/export` — admin-only CSV download via `@json2csv/plainjs`
- **Feature usage instrumentation** — `smart-search.service` and `search.service` call `trackFeatureUsage` (smart-search tracks before delegating to hybrid-search to avoid double-counting)
- **Retention cron** (`30 2 * * *`) — archives monthly aggregates before deleting raw events older than 90 days (configurable via `ANALYTICS_RAW_RETENTION_DAYS`); stale visitor sessions cleaned up on the same schedule

### Insights Frontend (`c17895c`)
- New **Insights** tab in `DashboardLayout` (admin-only)
- `useVisitorHeartbeat` hook — fires `page_view` on route change and keepalive ping every 60 s (paused when tab is hidden)
- `useInsightsSummary` / `useInsightsFeatureTrends` TanStack Query hooks + `downloadInsightsCsv` utility
- `InsightsPage` with:
  - **6 KPI cards** — Total Visits, Unique Visitors, Active Users (5 min), Smart Search Uses, Hybrid Search Uses, Unique Visitors This Month
  - **4 Recharts charts** — Visits & Unique Visitors over time (line), Feature Usage Daily Trend (line), Feature Usage Totals (bar), Monthly Unique Visitors (line)
  - **Export CSV** button with 403-aware error alert
- Added `recharts ^3.8.1` to client dependencies

### Privacy Policy (`36dd34a`)
- Updated `TermsAndPrivacyModal` sections 2 & 3 (bilingual MK/EN) to accurately disclose:
  - `obrok_vid` httpOnly analytics cookie and its 1-year lifetime
  - Page-view events, 60 s heartbeat pings, smart/hybrid-search feature tracking
  - Temporary IP + User-Agent storage for security and reliability
  - 90-day raw-event deletion; anonymous monthly aggregates retained longer
  - Admin-only access to detailed reports