### PR TITLE
docs: add VitePress docs site, deployment wiring, and README rewrite

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,12 @@ jobs:
             sed -i '/VITE_RELEASE_VERSION/d' apps/client/.env
             echo "VITE_RELEASE_VERSION=$RELEASE_TAG" >> apps/client/.env
             
+            echo "--- Building Documentation ---"
+            cd apps/docs
+            npm ci
+            npm run docs:build
+            cd ../..
+            
             echo "--- Rebuilding Docker Containers ---"
             docker compose -f docker-compose.prod.yml up --build -d
             

--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -1,0 +1,31 @@
+name: Docs CI
+
+on:
+  pull_request:
+    paths:
+      - "apps/docs/**"
+      - ".github/workflows/docs-ci.yml"
+
+jobs:
+  docs-build:
+    name: Build Documentation
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: ./apps/docs
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+
+      - name: Install docs dependencies
+        run: npm ci
+
+      - name: Build docs
+        run: npm run docs:build

--- a/.gitignore
+++ b/.gitignore
@@ -43,5 +43,9 @@ data/certbot/*
 apps/server/src/uploads/*
 !apps/server/src/uploads/.gitkeep
 
+# Docs
+apps/docs/.vitepress/cache/*
+apps/docs/.vitepress/dist/*
+
 #Generated reports
 apps/server/src/data/reports/*

--- a/README.md
+++ b/README.md
@@ -22,6 +22,48 @@ docker compose -f docker-compose.dev.yml up --build
 *   **Frontend:** `http://localhost:3500`
 *   **Backend API:** `http://localhost:5000`
 *   **OSRM Routing:** `http://localhost:5001`
+*   **Docs (VitePress):** `http://localhost:5173`
+
+---
+
+## 📚 Engineering Documentation (VitePress)
+
+Architecture, backend, frontend, deployment, and design-pattern documentation lives in `apps/docs/`.
+
+Run locally:
+
+```bash
+cd apps/docs
+npm install
+npm run docs:dev
+```
+
+Run in Docker Compose dev:
+
+```bash
+docker compose -f docker-compose.dev.yml build docs
+docker compose -f docker-compose.dev.yml up docs
+```
+
+Or run the full stack including docs:
+
+```bash
+docker compose -f docker-compose.dev.yml up --build
+```
+
+If docs dependencies change, rebuild the docs service image:
+
+```bash
+docker compose -f docker-compose.dev.yml build docs
+```
+
+Build and preview:
+
+```bash
+cd apps/docs
+npm run docs:build
+npm run docs:preview
+```
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,36 +1,62 @@
-# Student Obrok 🍽️🎓
+# Student Obrok
 
-Student Obrok is a modern web application designed to help university students find affordable, budget-friendly meal deals around their location via an interactive 3D map. 
+Student Obrok is an open source web application for discovering student-friendly meal offers on an interactive map.
 
-Built with a feature-sliced React frontend (Vite, Zustand, TanStack Query, MapLibre GL) and a robust Express 5 / MongoDB backend. Routing is handled via a dedicated OSRM instance.
+Built with a React frontend, an Express and MongoDB backend, OSRM routing, and a VitePress documentation site.
 
----
+[Documentation](https://docs.obrok.net) | [Website](https://obrok.net) | [Environment Templates](./ENV_TEMPLATES.md) | [License](./LICENSE)
 
-## 🚀 Quick Start (Development)
+## Why Student Obrok?
 
-The entire development environment is fully containerized.
+Students usually piece together meal options from scattered menus, social posts, and map searches that are not built for price-sensitive, location-aware decisions. Student Obrok brings those concerns into one system: nearby offers, routing, searchable data, and supporting operational tooling.
 
-1. Clone the repository.
-2. Ensure you have Docker and Docker Compose installed.
-3. Configure your `.env` and `apps/client/.env` files (See [ENV_TEMPLATES.md](./ENV_TEMPLATES.md)).
-4. Download the necessary OpenStreetMap `.osrm` data and place it in `/data/map`.
-5. Run the dev environment:
+The goal is straightforward: make affordable food options easier to discover, inspect, and compare without requiring users to jump between multiple tools.
+
+## What It Includes
+
+- Interactive map browsing for nearby offers and locations
+- Route-aware travel estimates through OSRM
+- Search and filtering across chains, markets, and products
+- Reporting, insights, feature flags, and supporting admin flows
+- Self-hosted development and deployment with Docker Compose
+- Maintained engineering documentation for architecture and operations
+
+## Repository Layout
+
+- `apps/client` contains the React frontend built with Vite
+- `apps/server` contains the Express API, data workflows, and background jobs
+- `apps/docs` contains the VitePress documentation site
+- `apps/nginx` contains the production reverse proxy configuration
+- `data/map` stores OSRM routing data used by the map service
+
+## Quick Start
+
+The fastest way to run the project locally is through Docker Compose.
+
+### Prerequisites
+
+1. Install Docker and Docker Compose.
+2. Configure the root `.env` file and `apps/client/.env` using [ENV_TEMPLATES.md](./ENV_TEMPLATES.md).
+3. Prepare OSRM data under `data/map`.
+
+### Run the full stack
 
 ```bash
 docker compose -f docker-compose.dev.yml up --build
 ```
-*   **Frontend:** `http://localhost:3500`
-*   **Backend API:** `http://localhost:5000`
-*   **OSRM Routing:** `http://localhost:5001`
-*   **Docs (VitePress):** `http://localhost:5173`
 
----
+### Local endpoints
 
-## 📚 Engineering Documentation (VitePress)
+- Frontend: `http://localhost:3500`
+- Backend API: `http://localhost:5000`
+- OSRM: `http://localhost:5001`
+- Docs: `http://localhost:5173`
 
-Architecture, backend, frontend, deployment, and design-pattern documentation lives in `apps/docs/`.
+## Documentation
 
-Run locally:
+Project documentation lives in `apps/docs` and is published at [docs.obrok.net](https://docs.obrok.net). It covers architecture, backend modules, frontend flows, deployment, and engineering patterns.
+
+### Run docs locally
 
 ```bash
 cd apps/docs
@@ -38,26 +64,14 @@ npm install
 npm run docs:dev
 ```
 
-Run in Docker Compose dev:
+### Run docs in Docker Compose
 
 ```bash
 docker compose -f docker-compose.dev.yml build docs
 docker compose -f docker-compose.dev.yml up docs
 ```
 
-Or run the full stack including docs:
-
-```bash
-docker compose -f docker-compose.dev.yml up --build
-```
-
-If docs dependencies change, rebuild the docs service image:
-
-```bash
-docker compose -f docker-compose.dev.yml build docs
-```
-
-Build and preview:
+### Build docs for verification
 
 ```bash
 cd apps/docs
@@ -65,27 +79,45 @@ npm run docs:build
 npm run docs:preview
 ```
 
----
+## Development
 
-## 🌍 Production Deployment
+The repository is structured as a small monorepo with separate client, server, docs, and infrastructure directories.
 
-Production relies on Nginx for reverse-proxying and Let's Encrypt (Certbot) for automated SSL generation and renewal.
+For day-to-day development:
 
-### First-Time Server Setup
-When deploying to a brand new VPS, you must generate the initial SSL certificates. We have automated the "Chicken and Egg" Nginx/SSL problem. 
+- Use `docker-compose.dev.yml` to run the full stack locally
+- Keep route data under `data/map` up to date before testing routing behavior
+- Use `apps/docs` for architecture and operational documentation updates alongside code changes
 
-Simply run:
+## Production
+
+Production runs behind Nginx with TLS handled by Let's Encrypt via Certbot. The production stack is defined in `docker-compose.prod.yml`.
+
+### First-time server setup
+
+For a new VPS, bootstrap certificates and start the stack with:
+
 ```bash
 ./init-ssl.sh
 ```
-This script will generate dummy certs, boot Nginx, fetch real Let's Encrypt certificates, reload the web server, and start the application.
 
-### CI/CD automated deployments
-This project uses GitHub Actions for CI/CD. 
-To deploy a new version to production:
-1. Push your code to the `main` branch.
-2. In GitHub, go to **Releases** -> **Draft a new release**.
-3. Create a tag using Calendar Versioning (e.g., `v2026.03.13.1`).
+The script creates temporary certificates, starts Nginx, requests real certificates, reloads the web server, and brings the application online.
+
+### Release workflow
+
+Deployments are triggered from GitHub Actions on published releases.
+
+1. Push the required changes.
+2. Create a GitHub release.
+3. Tag the release using the existing Calendar Versioning pattern, for example `v2026.03.13.1`.
 4. Publish the release.
 
-The GitHub Action will automatically SSH into the VPS, pull the tagged code, inject the dynamic version number into the frontend, and rebuild the Docker containers with zero manual intervention. SSL renewals are handled automatically in the background via the Docker containers.
+The deployment workflow connects to the VPS, pulls the tagged revision, rebuilds the docs site, injects the release version into the frontend environment, and recreates the production containers.
+
+## Contributing
+
+Contributions should keep code, deployment behavior, and documentation aligned. If a change affects architecture, flows, or operations, update the relevant docs in `apps/docs` as part of the same change set.
+
+## License
+
+This project is licensed under the terms in [LICENSE](./LICENSE).

--- a/README.md
+++ b/README.md
@@ -1,22 +1,24 @@
 # Student Obrok
 
-Student Obrok is an open source web application for discovering student-friendly meal offers on an interactive map.
+Student Obrok is an open source web application that scrapes product data from nearby market chains and helps users plan affordable meals from real store inventory.
 
-Built with a React frontend, an Express and MongoDB backend, OSRM routing, and a VitePress documentation site.
+It combines a React frontend, an Express and MongoDB backend, OSRM routing, and a VitePress documentation site.
 
 [Documentation](https://docs.obrok.net) | [Website](https://obrok.net) | [Environment Templates](./ENV_TEMPLATES.md) | [License](./LICENSE)
 
 ## Why Student Obrok?
 
-Students usually piece together meal options from scattered menus, social posts, and map searches that are not built for price-sensitive, location-aware decisions. Student Obrok brings those concerns into one system: nearby offers, routing, searchable data, and supporting operational tooling.
+Students looking for affordable meals usually have to jump between market flyers, store searches, recipe ideas, and map tools. That workflow is fragmented, hard to compare, and not especially useful when the real question is what meal can be made from products that are actually available nearby.
 
-The goal is straightforward: make affordable food options easier to discover, inspect, and compare without requiring users to jump between multiple tools.
+Student Obrok brings those pieces together. It collects product data from nearby chains, lets users search ingredients directly, and includes an AI recipe decomposition flow that turns meal searches into ingredient lists tied to real markets.
 
 ## What It Includes
 
-- Interactive map browsing for nearby offers and locations
-- Route-aware travel estimates through OSRM
-- Search and filtering across chains, markets, and products
+- Scraped product data from nearby market chains
+- AI recipe decomposition for meal-oriented search and ingredient-based results
+- Ingredient-level search across chains, markets, and products
+- Interactive map browsing for markets and nearby locations
+- Route-aware travel estimates to selected markets through OSRM
 - Reporting, insights, feature flags, and supporting admin flows
 - Self-hosted development and deployment with Docker Compose
 - Maintained engineering documentation for architecture and operations

--- a/apps/docs/.vitepress/config.mts
+++ b/apps/docs/.vitepress/config.mts
@@ -1,0 +1,128 @@
+import { defineConfig } from "vitepress";
+import { withMermaid } from "vitepress-plugin-mermaid";
+
+export default withMermaid(defineConfig({
+  title: "Student Obrok Docs",
+  description: "Architecture, backend, frontend, deployment, and engineering patterns.",
+  lang: "en-US",
+  cleanUrls: true,
+  lastUpdated: true,
+  sitemap: {
+    hostname: "https://docs.obrok.net",
+  },
+  markdown: {
+    lineNumbers: true,
+  },
+  themeConfig: {
+    logo: "/logo.svg",
+    search: {
+      provider: "local",
+    },
+    nav: [
+      { text: "Overview", link: "/" },
+      { text: "Architecture", link: "/architecture/overview" },
+      { text: "Backend", link: "/backend/overview" },
+      { text: "Frontend", link: "/frontend/overview" },
+      { text: "Deployment", link: "/deployment/overview" },
+      { text: "Patterns", link: "/patterns/catalog" },
+      { text: "Contributing", link: "/contributing/docs-process" },
+    ],
+    sidebar: [
+      {
+        text: "Start Here",
+        items: [
+          { text: "Home", link: "/" },
+          { text: "Documentation Charter", link: "/overview/docs-charter" },
+          { text: "How To Use This Site", link: "/overview/how-to-read" },
+        ],
+      },
+      {
+        text: "Architecture",
+        items: [
+          { text: "System Overview", link: "/architecture/overview" },
+          { text: "Data And Request Flows", link: "/architecture/flows" },
+        ],
+      },
+      {
+        text: "Backend",
+        items: [
+          { text: "Backend Overview", link: "/backend/overview" },
+          { text: "Auth And Security", link: "/backend/auth-security" },
+          { text: "Scraper And Search Pipeline", link: "/backend/scraper-search" },
+          { text: "Jobs, Cron, And Reports", link: "/backend/jobs-cron-reports" },
+          {
+            text: "Module Reference",
+            collapsed: true,
+            items: [
+              { text: "Auth", link: "/backend/modules/auth" },
+              { text: "Chain", link: "/backend/modules/chain" },
+              { text: "Market", link: "/backend/modules/market" },
+              { text: "Product", link: "/backend/modules/product" },
+              { text: "Scraper", link: "/backend/modules/scraper" },
+              { text: "Search", link: "/backend/modules/search" },
+              { text: "Report", link: "/backend/modules/report" },
+              { text: "Analytics", link: "/backend/modules/analytics" },
+              { text: "Feature Flag", link: "/backend/modules/feature-flag" },
+              { text: "Image", link: "/backend/modules/image" },
+              { text: "Public Holiday", link: "/backend/modules/public-holiday" },
+            ],
+          },
+        ],
+      },
+      {
+        text: "Frontend",
+        items: [
+          { text: "Frontend Overview", link: "/frontend/overview" },
+          { text: "Routing And Access Control", link: "/frontend/routing-auth" },
+          { text: "State And Server Data", link: "/frontend/state-data" },
+          { text: "Map And UX Flows", link: "/frontend/map-flows" },
+          {
+            text: "Feature Reference",
+            collapsed: true,
+            items: [
+              { text: "Auth", link: "/frontend/features/auth" },
+              { text: "Map", link: "/frontend/features/map" },
+              { text: "Dashboard", link: "/frontend/features/dashboard" },
+              { text: "CRUD Entities", link: "/frontend/features/crud-entities" },
+              { text: "Insights, Reports & Flags", link: "/frontend/features/insights-reports-flags" },
+            ],
+          },
+        ],
+      },
+      {
+        text: "Deployment",
+        items: [
+          { text: "Deployment Overview", link: "/deployment/overview" },
+          { text: "Development Environment", link: "/deployment/dev-environment" },
+          { text: "Production Environment", link: "/deployment/prod-environment" },
+          { text: "docs.obrok.net Hosting", link: "/deployment/docs-obrok-net" },
+          { text: "Runbooks", link: "/deployment/runbooks" },
+        ],
+      },
+      {
+        text: "Patterns",
+        items: [
+          { text: "Pattern Catalog", link: "/patterns/catalog" },
+          { text: "Architecture Decision Records", link: "/patterns/adrs" },
+        ],
+      },
+      {
+        text: "Contributing",
+        items: [
+          { text: "Docs Process", link: "/contributing/docs-process" },
+        ],
+      },
+    ],
+    socialLinks: [
+      { icon: "github", link: "https://github.com/martintrifunov/student-obrok" },
+    ],
+    editLink: {
+      pattern: "https://github.com/martintrifunov/student-obrok/edit/main/apps/docs/:path",
+      text: "Edit this page on GitHub",
+    },
+    footer: {
+      message: "Student Obrok engineering documentation.",
+      copyright: "Copyright 2026",
+    },
+  },
+}));

--- a/apps/docs/Dockerfile.dev
+++ b/apps/docs/Dockerfile.dev
@@ -1,0 +1,16 @@
+FROM node:24-alpine
+
+WORKDIR /app
+RUN apk add --no-cache git
+RUN chown node:node /app
+USER node
+
+COPY package.json package-lock.json ./
+
+RUN npm ci
+
+COPY . .
+
+EXPOSE 5173
+
+CMD ["npm", "run", "docs:dev", "--", "--host", "0.0.0.0", "--port", "5173"]

--- a/apps/docs/architecture/flows.md
+++ b/apps/docs/architecture/flows.md
@@ -1,0 +1,83 @@
+---
+title: Data And Request Flows
+---
+
+# Data And Request Flows
+
+## Public Summary
+
+The platform has three critical flows:
+
+- User request flow (client to API and routing).
+- Data ingestion flow (scrapers into MongoDB).
+- Search enrichment flow (embeddings and smart search).
+
+## Internal Details
+
+### User Request Flow
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant C as Client
+  participant N as Nginx
+  participant A as API
+  participant D as MongoDB
+  U->>C: Interact with UI
+  C->>N: /api/* request
+  N->>A: Proxy request
+  A->>D: Query/write data
+  D-->>A: Result
+  A-->>C: JSON response
+  C-->>U: Render update
+```
+
+### Scraper Ingestion Flow
+
+```mermaid
+sequenceDiagram
+  participant Cron as Scraper Cron
+  participant S as ScraperService
+  participant G as GeocoderService
+  participant D as MongoDB
+  Cron->>S: Trigger scheduled scrape
+  S->>S: Run market-specific scrapers
+  S->>G: Geocode market coordinates
+  S->>D: Upsert chains/markets/products
+  S->>S: Trigger embedding sync (if enabled)
+```
+
+### Search Flow
+
+```mermaid
+sequenceDiagram
+  participant UI as Client Search UI
+  participant API as Search/SmartSearch Routes
+  participant SS as Search Services
+  participant EMB as Embedding Service
+  participant DB as MongoDB
+  UI->>API: Search query
+  API->>SS: Parse intent and execute strategy
+  SS->>EMB: Generate query embedding
+  EMB-->>SS: Query vector
+  SS->>DB: Vector + keyword search
+  DB-->>SS: Matched products
+  SS-->>API: Ranked results (RRF merge)
+  API-->>UI: Search response
+```
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/modules/scraper/scraper.cron.js` | Cron trigger for ingestion flow |
+| `apps/server/src/modules/scraper/scraper.service.js` | Scraper orchestration |
+| `apps/server/src/modules/search/search.service.js` | Hybrid search (vector + keyword + RRF) |
+| `apps/server/src/modules/search/smart-search.service.js` | Recipe and budget-aware search |
+| `apps/client/src/features/map/pages/MapPage.jsx` | User-facing search and routing UI |
+
+## Risks and Trade-offs
+
+- Scraper reliability depends on external HTML structure stability.
+- Embedding generation depends on third-party API availability and quota.
+- Search quality and performance are coupled to embedding freshness.

--- a/apps/docs/architecture/overview.md
+++ b/apps/docs/architecture/overview.md
@@ -1,0 +1,64 @@
+---
+title: System Architecture Overview
+---
+
+# System Architecture Overview
+
+## Public Summary
+
+Student Obrok is a containerized full-stack system where a React client consumes an Express API, while OSRM provides route computation and MongoDB stores application data.
+
+## Internal Details
+
+### Runtime Topology
+
+```mermaid
+flowchart LR
+  User[Browser User] --> Nginx[Nginx Reverse Proxy]
+  Nginx --> Client[Static Client App]
+  Nginx --> API[Express API]
+  Nginx --> OSRM[OSRM Routing Service]
+  API --> Mongo[(MongoDB)]
+  API --> Uploads[Uploads Storage]
+  Certbot[Certbot] --> Nginx
+```
+
+### Backend Layering
+
+```mermaid
+flowchart TD
+  Router[Express Routes] --> Controller[Controllers]
+  Controller --> Service[Services]
+  Service --> Repository[Repositories]
+  Repository --> Model[Mongoose Models]
+```
+
+### Frontend Layering
+
+```mermaid
+flowchart TD
+  Entry[entry.jsx] --> Providers[Providers]
+  Providers --> Router[Router + Guards]
+  Router --> FeatureUI[Feature Pages]
+  FeatureUI --> DataHooks[React Query Hooks]
+  FeatureUI --> Stores[Zustand Stores]
+  DataHooks --> API[Axios API Layer]
+```
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/app.js` | Middleware stack and route mounting |
+| `apps/server/src/server.js` | Startup lifecycle and cron initialization |
+| `apps/server/src/container.js` | DI composition root |
+| `apps/client/src/entry.jsx` | Frontend provider chain |
+| `apps/client/src/components/layout/App.jsx` | Route tree and guards |
+| `docker-compose.dev.yml` | Dev service topology |
+| `docker-compose.prod.yml` | Prod service topology |
+| `apps/nginx/nginx.conf` | Reverse proxy and static serving |
+
+## Risks and Trade-offs
+
+- API and cron execution share one process, which keeps deployment simple but couples web traffic and background workload.
+- Nginx currently serves SPA fallback for the app; docs hosting should use VitePress-friendly static routing rules to avoid incorrect fallback behavior.

--- a/apps/docs/backend/auth-security.md
+++ b/apps/docs/backend/auth-security.md
@@ -1,0 +1,55 @@
+---
+title: Auth And Security
+---
+
+# Auth And Security
+
+## Public Summary
+
+Authentication uses JWT access tokens and refresh tokens with cookie transport. Core security controls include helmet headers, CORS controls, and centralized error handling.
+
+## Internal Details
+
+### Token Flow
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant API as Auth API
+  participant DB as MongoDB
+  U->>API: Login credentials
+  API->>DB: Validate user and password hash
+  DB-->>API: User record
+  API-->>U: Access token + refresh cookie
+  U->>API: Protected request with access token
+  API-->>U: 200 or 403
+  U->>API: Refresh request (cookie)
+  API-->>U: New access token
+```
+
+### Security Controls
+
+- Helmet enabled with production CSP behavior.
+- Allowed origins enforced by CORS options.
+- JWT verification middleware protects private routes.
+- Error middleware converts internal failures to structured responses.
+
+### Hardening Backlog
+
+- Expand rate limiting beyond login.
+- Add stronger upload content verification.
+- Add operational alerting for abnormal auth failure patterns.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/modules/auth/` | Auth module (controller, service, routes, model) |
+| `apps/server/src/modules/auth/middleware/` | JWT verification, admin check, credentials |
+| `apps/server/src/config/corsOptions.js` | CORS origin enforcement |
+| `apps/server/src/shared/middleware/errorHandler.js` | Centralized error handler |
+| `apps/server/src/config/multerConfig.js` | File upload configuration |
+
+## Risks and Trade-offs
+
+- Refresh-token strategy balances usability and security, but multi-device token management requires strict monitoring and revocation practices.

--- a/apps/docs/backend/jobs-cron-reports.md
+++ b/apps/docs/backend/jobs-cron-reports.md
@@ -1,0 +1,49 @@
+---
+title: Jobs, Cron, And Reports
+---
+
+# Jobs, Cron, And Reports
+
+## Public Summary
+
+The API process runs scheduled jobs for scraping and analytics cleanup, and it supports asynchronous report generation with status tracking.
+
+## Internal Details
+
+### Scheduled Jobs
+
+- Scraper cron: market data ingestion and optional embedding sync.
+- Analytics cron: periodic retention cleanup and aggregation maintenance.
+
+### Report Lifecycle
+
+```mermaid
+stateDiagram-v2
+  [*] --> PENDING
+  PENDING --> PROCESSING : Worker picks up
+  PROCESSING --> COMPLETED : Report generated
+  PROCESSING --> FAILED : Error during generation
+  PROCESSING --> ABORTED : 5-minute timeout
+  PENDING --> CANCELLED : User cancels
+```
+
+### Report Workflow
+
+1. User requests report creation.
+2. Job state is persisted.
+3. Background processing generates output file.
+4. Client polls status and downloads when completed.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/modules/scraper/scraper.cron.js` | Scraper schedule (Mon/Thu 03:00) |
+| `apps/server/src/modules/analytics/analytics.cron.js` | Analytics cleanup (daily 02:30) |
+| `apps/server/src/modules/report/report.service.js` | Job orchestration and CSV generation |
+| `apps/server/src/modules/report/report.controller.js` | HTTP job lifecycle endpoints |
+
+## Risks and Trade-offs
+
+- In-memory active job tracking can lose transient job state on process restart.
+- Long-running work in API process should be monitored to avoid request latency impact.

--- a/apps/docs/backend/modules/analytics.md
+++ b/apps/docs/backend/modules/analytics.md
@@ -1,0 +1,60 @@
+---
+title: Analytics Module
+---
+
+# Analytics Module
+
+## Public Summary
+
+Tracks visitor and user behavior — page views, feature usage, session activity — and provides dashboard summaries with CSV export.
+
+## Internal Details
+
+### Files
+
+| File | Role |
+|------|------|
+| `analytics.controller.js` | HTTP handlers |
+| `analytics.service.js` | Aggregation and export logic |
+| `analytics.routes.js` | Route definitions |
+| `analytics.schema.js` | Zod validation |
+| `analytics.model.js` | Event and aggregate schemas |
+| `analytics.repository.js` | Data access |
+| `analytics.cron.js` | Daily cleanup cron |
+
+### Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `POST` | `/analytics/heartbeat` | Public | Track page view / activity |
+| `GET` | `/analytics/summary` | JWT | Dashboard summary data |
+| `GET` | `/analytics/feature-trends` | JWT | Feature usage trends |
+| `GET` | `/analytics/export` | JWT (admin) | CSV export |
+
+### Data Models
+
+**AnalyticsEvent**
+```
+type     : PAGE_VIEW | HEARTBEAT | FEATURE_USAGE
+visitorId: String
+userId   : ObjectId → User (optional)
+metadata : Object
+createdAt: Date
+```
+
+**AnalyticsMonthlyAggregate** — pre-computed monthly rollups.
+
+### Cron Job
+
+- **Daily at 02:30**: purges raw events older than 90 days.
+- Monthly aggregates are retained indefinitely.
+
+### Dual Identity Tracking
+
+Events track both anonymous `visitorId` (cookie-based) and authenticated `userId` when available, allowing correlation of pre-login and post-login behavior.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/modules/analytics/` | Controller, service, routes, schema, model, repository, cron |

--- a/apps/docs/backend/modules/auth.md
+++ b/apps/docs/backend/modules/auth.md
@@ -1,0 +1,82 @@
+---
+title: Auth Module
+---
+
+# Auth Module
+
+## Public Summary
+
+JWT-based authentication with secure token rotation, refresh token reuse detection, and rate-limited login.
+
+## Internal Details
+
+### Files
+
+| File | Role |
+|------|------|
+| `auth.controller.js` | HTTP handlers for login, logout, refresh |
+| `auth.service.js` | Authentication business logic |
+| `auth.routes.js` | Route definitions with middleware |
+| `auth.schema.js` | Zod validation schemas |
+| `user.model.js` | Mongoose User schema |
+| `auth.repository.js` | User data access |
+| `token.service.js` | JWT sign/verify utilities |
+
+### Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `POST` | `/login` | Public (rate-limited) | Authenticate user |
+| `GET` | `/logout` | Cookie | Clear tokens and invalidate session |
+| `GET` | `/refresh` | Cookie | Rotate access token via refresh token |
+
+### Data Model — User
+
+```
+username    : String (unique, required)
+password    : String (bcrypt hash)
+refreshToken: [String] — array of active refresh tokens
+```
+
+### Token Flow
+
+```mermaid
+sequenceDiagram
+    participant C as Client
+    participant A as Auth Service
+    participant DB as MongoDB
+    C->>A: POST /login (username, password)
+    A->>DB: Find user, compare hash
+    A-->>C: accessToken (header) + refreshToken (httpOnly cookie)
+    C->>A: GET /refresh (cookie)
+    A->>DB: Validate + rotate refresh token
+    A-->>C: New accessToken + rotated refreshToken
+```
+
+### Security Controls
+
+- **Rate limiting** on `/login` to prevent brute-force attacks.
+- **Refresh token rotation**: old token is replaced on each refresh call.
+- **Reuse detection**: if a previously-rotated token is presented, all tokens for that user are wiped — forces full re-login.
+- **httpOnly, secure, sameSite** cookie flags on refresh tokens.
+
+### Extension Points
+
+- Add roles/permissions by extending the User model and `verifyAdminUser` middleware.
+- Add OAuth providers by creating alternative auth strategies in the service layer.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/modules/auth/` | Controller, service, routes, schema, model, repository |
+| `apps/server/src/modules/auth/middleware/` | verifyJWT, verifyAdminUser, optionalVerifyJWT, credentials |
+
+## Failure Modes
+
+| Failure | Behavior |
+|---------|----------|
+| Invalid credentials | 401 with generic message |
+| Expired refresh token | 403, client redirects to login |
+| Token reuse detected | All user tokens wiped, 403 |
+| Rate limit exceeded | 429, retry after cooldown |

--- a/apps/docs/backend/modules/chain.md
+++ b/apps/docs/backend/modules/chain.md
@@ -1,0 +1,55 @@
+---
+title: Chain Module
+---
+
+# Chain Module
+
+## Public Summary
+
+Manages supermarket chain entities (e.g. Vero, Ramstore) with image association and cascading relationships to markets and products.
+
+## Internal Details
+
+### Files
+
+Standard CRUD layer: controller, service, routes, schema, model, repository (7 files).
+
+### Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/chains` | Public | List chains (paginated, searchable) |
+| `GET` | `/chains/:id` | JWT | Get chain detail |
+| `POST` | `/chains` | JWT | Create chain |
+| `PUT` | `/chains/:id` | JWT | Update chain |
+| `DELETE` | `/chains/:id` | JWT | Delete chain + cascade |
+| `GET` | `/chains/report` | JWT | CSV report |
+
+### Data Model — Chain
+
+```
+name  : String (unique, required)
+image : ObjectId → Image (optional)
+```
+
+Virtual: `markets` — populated via Market.chain back-reference.
+
+### Cascade Delete
+
+Deleting a chain removes:
+1. All associated **Markets** linked to the chain.
+2. All **MarketProduct** junction records for those markets.
+
+```mermaid
+flowchart TD
+    A[Delete Chain] --> B[Find Markets by chain]
+    B --> C[Delete MarketProducts for each market]
+    C --> D[Delete Markets]
+    D --> E[Delete Chain document]
+```
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/modules/chain/` | Controller, service, routes, schema, model, repository |

--- a/apps/docs/backend/modules/feature-flag.md
+++ b/apps/docs/backend/modules/feature-flag.md
@@ -1,0 +1,54 @@
+---
+title: Feature Flag Module
+---
+
+# Feature Flag Module
+
+## Public Summary
+
+Runtime feature toggles for conditional feature enablement across the application.
+
+## Internal Details
+
+### Files
+
+Standard CRUD layer: controller, service, routes, schema, model, repository (7 files).
+
+### Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/flags` | Public | Key-value flag list (public consumption) |
+| `GET` | `/flags/admin` | JWT | Detailed flag list with metadata |
+| `PUT` | `/flags/:id` | JWT | Toggle flag |
+
+### Data Model — FeatureFlag
+
+```
+key        : String (unique, required)
+enabled    : Boolean (default: false)
+description: String
+```
+
+### Current Flags
+
+| Key | Purpose |
+|-----|---------|
+| `ai-search` | Enables hybrid vector+keyword search |
+| `smart-search` | Enables recipe decomposition search |
+
+### Integration Pattern
+
+Backend services check flags at runtime:
+```js
+const flag = await featureFlagService.getByKey('ai-search');
+if (flag?.enabled) { /* use AI path */ }
+```
+
+Frontend fetches flags on load via `featureFlagStore` and gates UI components.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/modules/feature-flag/` | Controller, service, routes, schema, model, repository |

--- a/apps/docs/backend/modules/image.md
+++ b/apps/docs/backend/modules/image.md
@@ -1,0 +1,60 @@
+---
+title: Image Module
+---
+
+# Image Module
+
+## Public Summary
+
+Image upload, filesystem storage, and metadata management. Shared image library used by chains and products.
+
+## Internal Details
+
+### Files
+
+| File | Role |
+|------|------|
+| `image.controller.js` | HTTP handlers |
+| `image.service.js` | Upload orchestration |
+| `image.routes.js` | Route definitions |
+| `image.schema.js` | Zod validation |
+| `image.model.js` | Mongoose schema |
+| `image.repository.js` | Data access |
+| `file.service.js` | Filesystem operations |
+
+### Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/images` | JWT | List images (paginated) |
+| `POST` | `/images` | JWT | Upload image (multipart) |
+| `DELETE` | `/images/:id` | JWT | Remove image + file |
+
+### Data Model — Image
+
+```
+title   : String (required)
+filename: String
+url     : String (computed)
+mimeType: String
+size    : Number
+```
+
+### Upload Flow
+
+1. Multer middleware handles multipart parsing and writes file to `apps/server/src/uploads/`.
+2. Image metadata record is created in MongoDB.
+3. URL is computed from the configured base URL + filename.
+4. On error, filesystem cleanup removes the uploaded file.
+
+### File Serving
+
+Uploaded files are served via the `/uploads/` route, which proxies to the API container in production.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/modules/image/` | Controller, service, routes, schema, model, repository |
+| `apps/server/src/config/multerConfig.js` | Upload middleware configuration |
+| `apps/server/src/uploads/` | Filesystem storage for uploaded files |

--- a/apps/docs/backend/modules/market.md
+++ b/apps/docs/backend/modules/market.md
@@ -1,0 +1,50 @@
+---
+title: Market Module
+---
+
+# Market Module
+
+## Public Summary
+
+Store locations with GeoJSON coordinates, chain association, and product pricing integration.
+
+## Internal Details
+
+### Files
+
+Standard CRUD layer: controller, service, routes, schema, model, repository (7 files).
+
+### Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/markets` | Public | List markets (searchable by name/chain) |
+| `GET` | `/markets/:id` | Public | Market detail with products |
+| `POST` | `/markets` | JWT | Create market |
+| `PUT` | `/markets/:id` | JWT | Update market |
+| `DELETE` | `/markets/:id` | JWT | Delete market + cascade |
+
+### Data Model — Market
+
+```
+name             : String (required)
+location         : [Number, Number] — [longitude, latitude]
+chain            : ObjectId → Chain (required)
+lastScrapedUpdate: Date
+```
+
+Virtual: `products` — populated via MarketProduct back-reference.
+
+### GeoJSON Convention
+
+Coordinates are stored as `[longitude, latitude]` (GeoJSON order), not `[lat, lon]`.
+
+### Cascade Delete
+
+Deleting a market removes all **MarketProduct** junction records for that market.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/modules/market/` | Controller, service, routes, schema, model, repository |

--- a/apps/docs/backend/modules/product.md
+++ b/apps/docs/backend/modules/product.md
@@ -1,0 +1,74 @@
+---
+title: Product Module
+---
+
+# Product Module
+
+## Public Summary
+
+Product catalog with multi-market pricing via a junction table. Supports category filtering, price ranges, and market-scoped queries.
+
+## Internal Details
+
+### Files
+
+| File | Role |
+|------|------|
+| `product.controller.js` | HTTP handlers |
+| `product.service.js` | Business logic |
+| `product.routes.js` | Route definitions |
+| `product.schema.js` | Zod validation |
+| `product.model.js` | Mongoose Product schema |
+| `product.repository.js` | Product data access |
+| `marketProduct.model.js` | Junction table schema |
+| `marketProduct.repository.js` | Junction data access |
+
+### Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/products` | Public | List products (filter by title, category, market, price range) |
+| `GET` | `/products/categories` | Public | Category list (optionally scoped to market) |
+| `GET` | `/products/:id` | Public | Product detail |
+| `POST` | `/products` | JWT | Create product |
+| `PUT` | `/products/:id` | JWT | Update product |
+| `DELETE` | `/products/:id` | JWT | Delete product |
+
+### Data Models
+
+**Product**
+```
+title      : String (unique, required)
+category   : String (required)
+description: String
+image      : ObjectId → Image (optional)
+```
+
+**MarketProduct** (junction table)
+```
+market  : ObjectId → Market (required)
+product : ObjectId → Product (required)
+price   : Number (required)
+```
+
+Unique compound index on `(market, product)` — one price per product per market.
+
+### Many-to-Many Relationship
+
+```mermaid
+erDiagram
+    CHAIN ||--o{ MARKET : has
+    MARKET ||--o{ MARKET_PRODUCT : stocks
+    PRODUCT ||--o{ MARKET_PRODUCT : "priced at"
+    MARKET_PRODUCT {
+        ObjectId market
+        ObjectId product
+        Number price
+    }
+```
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/modules/product/` | Controller, service, routes, schema, models (Product + MarketProduct) |

--- a/apps/docs/backend/modules/public-holiday.md
+++ b/apps/docs/backend/modules/public-holiday.md
@@ -1,0 +1,42 @@
+---
+title: Public Holiday Module
+---
+
+# Public Holiday Module
+
+## Public Summary
+
+Manages public holiday dates used by smart search budget calculations and work schedule awareness.
+
+## Internal Details
+
+### Files
+
+Standard CRUD layer: controller, service, routes, schema, model, repository (7 files).
+
+### Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `GET` | `/public-holidays` | Public | List holidays (paginated, filterable) |
+| `GET` | `/public-holidays/:id` | JWT | Holiday detail |
+| `POST` | `/public-holidays` | JWT | Create holiday |
+| `PUT` | `/public-holidays/:id` | JWT | Update holiday |
+| `DELETE` | `/public-holidays/:id` | JWT | Delete holiday |
+
+### Data Model — PublicHoliday
+
+```
+name: String (required)
+date: Date (unique, required)
+```
+
+### Usage
+
+Smart search budget calculations use public holidays to adjust the number of working days in a period, affecting daily meal budget recommendations.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/modules/public-holiday/` | Controller, service, routes, schema, model, repository |

--- a/apps/docs/backend/modules/report.md
+++ b/apps/docs/backend/modules/report.md
@@ -1,0 +1,68 @@
+---
+title: Report Module
+---
+
+# Report Module
+
+## Public Summary
+
+Asynchronous report generation with a job queue, timeout enforcement, and CSV artifact download.
+
+## Internal Details
+
+### Files
+
+| File | Role |
+|------|------|
+| `report.controller.js` | HTTP handlers for job lifecycle |
+| `report.service.js` | Job orchestration and report generation |
+| `report.routes.js` | Route definitions |
+| `report.schema.js` | Zod validation |
+| `report-job.model.js` | Job state machine schema |
+| `report-job.repository.js` | Job data access |
+
+### Endpoints
+
+| Method | Path | Auth | Description |
+|--------|------|------|-------------|
+| `POST` | `/reports` | JWT | Create job → 202 Accepted with jobId |
+| `GET` | `/reports/:jobId` | JWT | Poll job status |
+| `POST` | `/reports/:jobId/cancel` | JWT | Cancel pending job |
+| `GET` | `/reports/:jobId/download` | JWT | Download CSV artifact |
+
+### Job State Machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> PENDING
+    PENDING --> PROCESSING: Worker picks up
+    PROCESSING --> COMPLETED: Report generated
+    PROCESSING --> FAILED: Error during generation
+    PROCESSING --> ABORTED: 5-minute timeout
+    PENDING --> CANCELLED: User cancels
+```
+
+### Constraints
+
+- **One active job per user** — creating a new job while one is PENDING/PROCESSING is rejected.
+- **5-minute timeout** — jobs exceeding this are moved to ABORTED.
+- **Artifacts** stored as CSV files on the filesystem.
+
+### Data Model — ReportJob
+
+```
+requestedBy: String
+filters    : Object (date range, scope, etc.)
+status     : PENDING | PROCESSING | COMPLETED | FAILED | CANCELLED | ABORTED
+artifact   : String (file path to CSV)
+error      : String (failure reason)
+createdAt  : Date
+updatedAt  : Date
+```
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/modules/report/` | Controller, service, routes, schema, model, repository |
+| `apps/server/src/data/reports/` | CSV artifact storage directory |

--- a/apps/docs/backend/modules/scraper.md
+++ b/apps/docs/backend/modules/scraper.md
@@ -1,0 +1,93 @@
+---
+title: Scraper Module
+---
+
+# Scraper Module
+
+## Public Summary
+
+Automated web scraping pipeline using Puppeteer with concurrent tabs, market discovery, price collection, geocoding, and post-scrape embedding generation. Runs on a twice-weekly cron schedule.
+
+## Internal Details
+
+### Files
+
+| File | Role |
+|------|------|
+| `scraper.service.js` | Orchestrator: launches browser, dispatches scrapers |
+| `scraper.cron.js` | Cron schedule definition |
+| `scraper.registry.js` | Plugin registry for market scrapers |
+| `geocoder.service.js` | Nominatim geocoding with caching |
+| `vero.scraper.js` | Vero market scraper |
+| `ramstore.scraper.js` | Ramstore scraper |
+| `stokomak.scraper.js` | Stokomak scraper |
+| `kam.scraper.js` | KAM scraper |
+| `superkitgo.scraper.js` | SuperKitGo scraper |
+| `kipper.scraper.js` | Kipper scraper |
+| `utils/` | Shared scraping utilities |
+
+### Cron Schedule
+
+- **When**: Monday and Thursday at 03:00
+- **Concurrency**: 2 tabs in production, 4 in development
+
+### Pipeline
+
+```mermaid
+flowchart TD
+    A[Cron Trigger] --> B[Launch Puppeteer Browser]
+    B --> C[Load Scraper Registry]
+    C --> D[For Each Registered Scraper]
+    D --> E[Open Concurrent Tabs]
+    E --> F[Navigate + Scrape Products/Prices]
+    F --> G[Geocode New Markets]
+    G --> H[Upsert Markets + Products + MarketProducts]
+    H --> I[Generate Embeddings for New/Changed Products]
+    I --> J[Close Browser]
+```
+
+### Strategy + Registry Pattern
+
+Each market scraper implements a common interface and registers itself in the scraper registry. The orchestrator iterates the registry without knowing scraper internals.
+
+```js
+// Each scraper exports: { name, scrape(page, deps) }
+registry.register(veroScraper);
+registry.register(ramstoreScraper);
+// ...
+```
+
+### Geocoding
+
+- **Primary**: Nominatim API lookup by market address.
+- **Fallback**: City center coordinates if address lookup fails.
+- **Caching**: Coordinates are cached to avoid redundant API calls.
+
+### Performance Optimizations
+
+- **Request interception**: blocks images, CSS, fonts during scraping.
+- **Navigation timeout**: 90 seconds per page.
+- **Batch processing**: concurrent tab pool limits resource usage.
+
+### Dependencies
+
+- Product, Market, MarketProduct modules (upsert data)
+- Image module (market images)
+- Search module (post-scrape embedding generation)
+- Feature Flag module (conditional behavior)
+- Geocoder service (Nominatim)
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/modules/scraper/` | Service, cron, registry, geocoder, market scrapers |
+
+## Failure Modes
+
+| Failure | Behavior |
+|---------|----------|
+| Scraper page timeout | Skip market, log error, continue |
+| Geocoding failure | Use city center fallback |
+| Embedding generation failure | Products saved without embeddings |
+| Browser crash | Cron retries on next scheduled run |

--- a/apps/docs/backend/modules/search.md
+++ b/apps/docs/backend/modules/search.md
@@ -1,0 +1,101 @@
+---
+title: Search Module
+---
+
+# Search Module
+
+## Public Summary
+
+Dual-mode AI-powered search: hybrid vector+keyword search for products and smart recipe-based search with geolocation and budget calculation.
+
+## Internal Details
+
+### Files
+
+| File | Role |
+|------|------|
+| `search.controller.js` | Hybrid search HTTP handler |
+| `search.service.js` | Hybrid search logic (vector + keyword + RRF) |
+| `search.routes.js` | Search route definitions |
+| `smart-search.controller.js` | Smart/recipe search HTTP handler |
+| `smart-search.service.js` | Recipe decomposition + geolocation logic |
+| `smart-search.routes.js` | Smart search route definitions |
+| `embedding.service.js` | Gemini embedding generation |
+| `product-embedding-sync.service.js` | Incremental embedding sync |
+| `intent-parser.service.js` | Gemini intent/query parsing |
+| `product-embedding.model.js` | Embedding vector storage |
+| `product-embedding.repository.js` | Embedding data access |
+
+### Hybrid Search (SearchService)
+
+**Endpoint**: `GET /search?q=...&marketId=...`
+
+```mermaid
+flowchart TD
+    A[User Query] --> B[Intent Parser]
+    B --> C{Parse Result}
+    C --> D[Vector Search via Embeddings]
+    C --> E[Keyword Search via MongoDB]
+    D --> F[Reciprocal Rank Fusion k=60]
+    E --> F
+    F --> G[Price Sort + Return]
+```
+
+1. **Intent parsing** via Gemini 2.5 Flash — detects search terms, price preference, language.
+2. **Parallel execution** of vector search (cosine similarity on embeddings) and keyword search (MongoDB text/regex).
+3. **RRF merge** with k=60 to combine ranked results.
+4. **Market scoping** optimization when `marketId` is provided.
+
+### Smart Search (SmartSearchService)
+
+**Endpoints**:
+- `GET /smart-search?q=...&lat=...&lon=...` — Recipe search with geolocation
+- `GET /smart-search/budget` — Weekly budget calculation
+
+```mermaid
+flowchart TD
+    A[Recipe Query] --> B[Intent Parser: Detect Recipe]
+    B --> C[Decompose into Ingredients]
+    C --> D[Per-Ingredient Market Search]
+    D --> E[Price Ranking per Market]
+    E --> F[Distance Calculation via Haversine]
+    F --> G[Combined Price + Distance Results]
+```
+
+### Embedding Service
+
+- **Model**: Gemini 2 text embeddings (768 dimensions)
+- **Batch processing**: rate-limited at 350ms between batches
+- **Retry**: exponential backoff on API busy/rate-limit responses
+
+### Intent Parser Service
+
+- **Model**: Gemini 2.5 Flash
+- **Bilingual**: Cyrillic + Latin Macedonian
+- **Detects**: recipe vs. product search, price preference (asc/desc), ingredient decomposition
+- **Cache**: 5-minute local cache, 500 entry max
+- **Fallback**: model fallback strategy if primary unavailable
+
+### Feature Flag Gates
+
+| Flag | Controls |
+|------|----------|
+| `ai-search` | Enables hybrid vector+keyword search |
+| `smart-search` | Enables recipe decomposition search |
+
+When flags are disabled, search falls back to basic keyword-only behavior.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/modules/search/` | All search services, controllers, routes, models |
+
+## Failure Modes
+
+| Failure | Behavior |
+|---------|----------|
+| Gemini API unavailable | Graceful degradation to keyword-only search |
+| Embedding generation fails | Products searchable via keyword only |
+| Intent parsing fails | Raw query used as-is |
+| Rate limit on embedding API | Exponential backoff retry |

--- a/apps/docs/backend/overview.md
+++ b/apps/docs/backend/overview.md
@@ -1,0 +1,46 @@
+---
+title: Backend Overview
+---
+
+# Backend Overview
+
+## Public Summary
+
+The backend is an Express service organized by modules and built with layered architecture: route/controller, service, repository, model.
+
+## Internal Details
+
+### Startup Lifecycle
+
+1. Load environment and initialize Express.
+2. Connect MongoDB.
+3. Seed required baseline data.
+4. Start scheduled jobs (scraper and analytics).
+5. Start HTTP server.
+
+### Middleware Stack (Order Matters)
+
+1. Helmet security headers.
+2. Credential handling and CORS.
+3. Body parsers and cookie parser.
+4. Visitor tracking.
+5. Route mounting.
+6. Centralized error handler.
+
+### Module Boundaries
+
+Main modules include auth, chain, product, market, image, scraper, search, feature-flag, public-holiday, report, and analytics.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/server.js` | Startup lifecycle |
+| `apps/server/src/app.js` | Middleware stack and route mounting |
+| `apps/server/src/container.js` | DI composition root |
+| `apps/server/src/modules/` | All module directories |
+
+## Risks and Trade-offs
+
+- Container wiring is explicit and readable, but growth in module count increases maintenance cost in one central file.
+- Cron jobs in the same process improve simplicity but reduce isolation from API workload.

--- a/apps/docs/backend/scraper-search.md
+++ b/apps/docs/backend/scraper-search.md
@@ -1,0 +1,50 @@
+---
+title: Scraper And Search Pipeline
+---
+
+# Scraper And Search Pipeline
+
+## Public Summary
+
+The backend periodically scrapes market data, normalizes it, stores it in MongoDB, and can enrich products with embeddings for search features.
+
+## Internal Details
+
+### Pipeline
+
+```mermaid
+flowchart LR
+  Cron[Scraper Cron] --> Scrapers[Market Scrapers]
+  Scrapers --> Normalize[Normalize + Deduplicate]
+  Normalize --> DB[(MongoDB)]
+  DB --> EmbSync[Embedding Sync]
+  EmbSync --> VectorStore[(Product Embeddings)]
+  VectorStore --> Search[Search Services]
+```
+
+### Strategy + Registry Design
+
+- Scrapers follow a shared base contract.
+- A registry maps source names to concrete scraper implementations.
+- The orchestrator executes multiple market scrapers in one run.
+
+### Feature Flag Integration
+
+- Search and embedding behavior can be gated by feature flags.
+- This enables controlled rollout for AI-driven features.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/server/src/modules/scraper/markets/base.scraper.js` | Shared scraper contract |
+| `apps/server/src/modules/scraper/scraper.registry.js` | Plugin registry |
+| `apps/server/src/modules/scraper/scraper.service.js` | Orchestrator (Puppeteer + concurrent tabs) |
+| `apps/server/src/modules/search/product-embedding-sync.service.js` | Incremental embedding sync |
+| `apps/server/src/modules/search/search.service.js` | Hybrid search (vector + keyword + RRF) |
+| `apps/server/src/modules/search/smart-search.service.js` | Recipe and budget-aware search |
+
+## Risks and Trade-offs
+
+- Upstream HTML changes can break scraper extraction logic.
+- Embedding provider outages can degrade smart-search behavior.

--- a/apps/docs/contributing/docs-process.md
+++ b/apps/docs/contributing/docs-process.md
@@ -1,0 +1,54 @@
+---
+title: Docs Process
+---
+
+# Docs Process
+
+## Public Summary
+
+Documentation changes are part of engineering changes. If architecture, flows, or deployment behavior changes, docs must be updated in the same delivery cycle.
+
+## Internal Details
+
+### Required Updates
+
+Update docs when you change:
+
+- Route structure or auth/permission behavior.
+- Data ingestion, search, or report lifecycle.
+- Deployment topology, SSL, environment variables, or release process.
+- State management or frontend routing/guard behavior.
+
+### Pull Request Checklist
+
+- Updated at least one relevant page in docs.
+- Verified docs build locally.
+- Added or updated diagrams if system flow changed.
+- Documented new risks or trade-offs.
+
+### CI and Deployment Behavior
+
+- Docs CI (.github/workflows/docs-ci.yml) validates docs builds on pull requests that touch apps/docs or the docs workflow.
+- Production deployment (.github/workflows/deploy.yml) runs on published releases and rebuilds docs during release deployment.
+- Result: docs quality is checked before merge, and docs are redeployed when a release is published.
+
+### Local Commands
+
+From docs folder:
+
+- npm install
+- npm run docs:dev
+- npm run docs:build
+- npm run docs:preview
+
+From repository root (Docker Compose):
+
+- docker compose -f docker-compose.dev.yml build docs
+- docker compose -f docker-compose.dev.yml up docs
+
+### Ownership
+
+- Backend pages: backend maintainers.
+- Frontend pages: frontend maintainers.
+- Deployment pages: release/ops maintainers.
+- Pattern catalog and ADRs: architecture owners.

--- a/apps/docs/deployment/dev-environment.md
+++ b/apps/docs/deployment/dev-environment.md
@@ -1,0 +1,44 @@
+---
+title: Development Environment
+---
+
+# Development Environment
+
+## Public Summary
+
+Development runs the full stack locally through Docker Compose, with direct access to frontend, docs, API, OSRM, and MongoDB ports.
+
+## Internal Details
+
+### Setup
+
+1. Configure root .env and apps/client/.env.
+2. Prepare map data via init-route-data.sh.
+3. Build and start the stack: docker compose -f docker-compose.dev.yml up --build.
+
+Optional docs-only startup:
+
+1. Build docs image once: docker compose -f docker-compose.dev.yml build docs
+2. Start docs service: docker compose -f docker-compose.dev.yml up docs
+
+### Service Endpoints (Default)
+
+- Frontend: localhost:3500
+- Docs (VitePress): localhost:5173
+- API: localhost:5000
+- OSRM: localhost:5001
+- MongoDB: localhost:6969
+
+### Notes
+
+- API waits for DB health.
+- Client and server code are mounted for live development.
+- Node modules are persisted in Docker volumes.
+- Docs service uses apps/docs/Dockerfile.dev so dependencies are installed at image-build time.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `docker-compose.dev.yml` | Dev service topology |
+| `init-route-data.sh` | OSRM map data preparation |

--- a/apps/docs/deployment/docs-obrok-net.md
+++ b/apps/docs/deployment/docs-obrok-net.md
@@ -1,0 +1,68 @@
+---
+title: docs.obrok.net Hosting
+---
+
+# docs.obrok.net Hosting
+
+## Public Summary
+
+The docs site should be deployed as static VitePress output and served from a dedicated Nginx host configuration for docs.obrok.net.
+
+## Internal Details
+
+### Build Output
+
+- Source: apps/docs/
+- Output: apps/docs/.vitepress/dist
+- Build command: npm run docs:build (inside apps/docs folder)
+
+### Nginx Serving Rules (Important)
+
+Use static file resolution for VitePress pages and clean URLs. Do not use SPA-style fallback to index.html for every unknown route.
+
+Example server block (conceptual):
+
+```nginx
+server {
+  listen 443 ssl;
+  server_name docs.obrok.net;
+  root /var/www/student-obrok-docs;
+  index index.html;
+
+  location / {
+    try_files $uri $uri.html $uri/ =404;
+    error_page 404 /404.html;
+  }
+
+  location ~* ^/assets/ {
+    expires 1y;
+    add_header Cache-Control "public, immutable";
+  }
+}
+```
+
+### Deployment Options
+
+1. Build docs in CI and rsync dist output to VPS docs root.
+2. Build docs directly on VPS after git pull and copy dist to web root.
+
+Option 1 is preferred for deterministic artifact deployment.
+
+### SSL Notes
+
+- Include docs.obrok.net in certbot issuance/renewal flow.
+- Ensure challenge location remains reachable if using HTTP challenge.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/docs/package.json` | Docs build scripts and dependencies |
+| `apps/docs/.vitepress/config.mts` | VitePress site configuration |
+| `apps/nginx/nginx.conf` | Nginx server block for docs.obrok.net |
+| `init-ssl.sh` | SSL certificate issuance including docs domain |
+
+## Risks and Trade-offs
+
+- Hosting docs separately from app domain improves isolation and cache behavior.
+- Additional server block and certificate lifecycle add operational surface area.

--- a/apps/docs/deployment/overview.md
+++ b/apps/docs/deployment/overview.md
@@ -1,0 +1,35 @@
+---
+title: Deployment Overview
+---
+
+# Deployment Overview
+
+## Public Summary
+
+Student Obrok uses Docker Compose for both development and production, with Nginx as production reverse proxy and Certbot for SSL renewal.
+
+## Internal Details
+
+### Environment Shapes
+
+- Development: client, docs, api, osrm, db with exposed ports and live mounts.
+- Production: nginx, certbot, api, osrm, db with internal networking and restricted DB exposure.
+
+### Docs Hosting Target
+
+Documentation should be built by VitePress and served at docs.obrok.net as static files on the same VPS infrastructure.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `docker-compose.dev.yml` | Dev service topology |
+| `docker-compose.prod.yml` | Prod service topology |
+| `apps/nginx/nginx.conf` | Reverse proxy and static serving |
+| `.github/workflows/deploy.yml` | Release-triggered deployment |
+| `init-ssl.sh` | First-time SSL bootstrap |
+| `init-route-data.sh` | OSRM map data preparation |
+
+## Risks and Trade-offs
+
+- Single VPS deployment reduces complexity but centralizes failure domain for app and docs workloads.

--- a/apps/docs/deployment/prod-environment.md
+++ b/apps/docs/deployment/prod-environment.md
@@ -1,0 +1,49 @@
+---
+title: Production Environment
+---
+
+# Production Environment
+
+## Public Summary
+
+Production uses Nginx as the public entrypoint, proxies API and routing services internally, and relies on Certbot for TLS certificate automation.
+
+## Internal Details
+
+### Current Runtime Topology
+
+```mermaid
+flowchart LR
+  Internet --> Nginx[Nginx :80/:443]
+  Nginx --> API[Express API]
+  Nginx --> OSRM[OSRM]
+  API --> DB[(MongoDB)]
+  Certbot[Certbot] --> Nginx
+```
+
+### Deployment Path
+
+- Release tag triggers test + VPS deploy workflow.
+- VPS checks out release tag and rebuilds production compose services.
+- Frontend release version is injected into apps/client/.env during deploy.
+
+### docs.obrok.net Target
+
+Recommended production model for docs:
+
+1. Build VitePress static output from apps/docs/.vitepress/dist.
+2. Serve through dedicated Nginx server_name docs.obrok.net.
+3. Use static try_files suitable for VitePress, not SPA index fallback.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `docker-compose.prod.yml` | Production service topology |
+| `apps/nginx/nginx.conf` | Reverse proxy, SSL, static serving |
+| `.github/workflows/deploy.yml` | Release-triggered deployment |
+| `init-ssl.sh` | First-time SSL bootstrap |
+
+## Risks and Trade-offs
+
+- App and docs on same VPS is operationally simple but increases blast radius during host-level incidents.

--- a/apps/docs/deployment/runbooks.md
+++ b/apps/docs/deployment/runbooks.md
@@ -1,0 +1,55 @@
+---
+title: Runbooks
+---
+
+# Runbooks
+
+## Public Summary
+
+Runbooks define routine operational tasks and incident responses for production.
+
+## Internal Details
+
+## 1. Service Health Check
+
+1. Verify containers: docker compose -f docker-compose.prod.yml ps
+2. Check API logs: docker compose -f docker-compose.prod.yml logs api --tail=200
+3. Check Nginx logs: docker compose -f docker-compose.prod.yml logs nginx --tail=200
+4. Validate DB health via compose health status.
+
+## 2. SSL Renewal Failure
+
+1. Confirm certbot container is running.
+2. Inspect certbot logs for ACME or DNS issues.
+3. Confirm challenge path is reachable in Nginx.
+4. Re-run init-ssl.sh if bootstrap assets are missing.
+
+## 3. OSRM Data Refresh
+
+1. Backup current map data folder.
+2. Run init-route-data.sh.
+3. Restart osrm service.
+4. Validate /route endpoint from application UI and API side.
+
+## 4. Report Generation Incident
+
+1. Check API logs for report service errors.
+2. Verify data/report output path write permissions.
+3. Verify MongoDB availability and query performance.
+4. Retry with smaller date range or lower scope while investigating.
+
+## 5. docs.obrok.net Validation
+
+1. Build docs from apps/docs folder (docs:build).
+2. Validate static output exists at apps/docs/.vitepress/dist.
+3. Confirm Nginx server_name docs.obrok.net serves static content and returns docs pages.
+4. Confirm HTTPS certificate issuance for docs domain.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `docker-compose.prod.yml` | Production service topology |
+| `init-ssl.sh` | SSL bootstrap script |
+| `init-route-data.sh` | OSRM data preparation |
+| `apps/server/src/modules/report/report.service.js` | Report generation logic |

--- a/apps/docs/frontend/features/auth.md
+++ b/apps/docs/frontend/features/auth.md
@@ -1,0 +1,56 @@
+---
+title: Auth Feature
+---
+
+# Auth Feature
+
+## Public Summary
+
+Handles login, session persistence, token refresh, and route protection on the client side.
+
+## Internal Details
+
+### Files
+
+| File | Role |
+|------|------|
+| `Login.jsx` | Login page with form |
+| `PersistLogin.jsx` | Wrapper that refreshes tokens on app load |
+| `RequireAuth.jsx` | Route guard — redirects to login if unauthenticated |
+| `useAuth.js` | Hook to access auth state |
+| `useLogout.js` | Hook to clear session |
+| `useRefreshToken.js` | Hook to silently refresh access token |
+
+### State Management
+
+- **`authStore`** (Zustand, persisted to localStorage): stores `auth` object and `persist` flag.
+- Access token kept in memory; refresh token in httpOnly cookie.
+
+### Route Protection Flow
+
+```mermaid
+flowchart TD
+    A[Route Request] --> B{PersistLogin}
+    B -->|persist enabled| C[Try Refresh Token]
+    C -->|success| D{RequireAuth}
+    C -->|fail| E[Login Page]
+    B -->|persist disabled| D
+    D -->|authenticated| F[Dashboard]
+    D -->|not authenticated| E
+```
+
+### Dependencies
+
+| Dependency | Usage |
+|------------|-------|
+| `authStore` | Auth state persistence |
+| `useAxiosPrivate` | Attach access token to API calls |
+| Axios | `/login`, `/logout` API calls |
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/client/src/features/auth/` | Login page, guards, auth hooks |
+| `apps/client/src/store/authStore.js` | Auth state (Zustand, persisted) |
+| `apps/client/src/hooks/useAxiosPrivate.js` | Token interceptor with 403 retry |

--- a/apps/docs/frontend/features/crud-entities.md
+++ b/apps/docs/frontend/features/crud-entities.md
@@ -1,0 +1,73 @@
+---
+title: CRUD Features — Chains, Markets, Products
+---
+
+# CRUD Features
+
+## Public Summary
+
+Chains, Markets, and Products share a common CRUD UI pattern: paginated list with search, add/edit form with validation, image association, and delete confirmation.
+
+## Internal Details
+
+### Shared Pattern
+
+Each CRUD feature follows the same structure:
+
+```
+feature/
+  ├── {Entity}List.jsx           # Paginated table with search
+  ├── {Entity}SearchBar.jsx      # Debounced search input
+  ├── AddOrEdit{Entity}Form.jsx  # Create/edit form
+  └── use{Entity}Queries.js      # React Query hooks
+```
+
+### React Query Conventions
+
+Each `use{Entity}Queries.js` file exports:
+
+| Hook | Query Key | Purpose |
+|------|-----------|---------|
+| `useEntities()` | `[entity, page, search]` | Paginated list |
+| `useEntity(id)` | `[entity, id]` | Single entity detail |
+| `useCreateEntity()` | mutation | Create with cache invalidation |
+| `useUpdateEntity()` | mutation | Update with cache invalidation |
+| `useDeleteEntity()` | mutation | Delete with cache invalidation |
+
+Mutations invalidate related query keys (e.g., deleting a chain invalidates markets and products).
+
+### Chains
+
+- Associates an image from the shared image library.
+- Cascade-deletes markets and market products on removal.
+- CSV report export endpoint.
+
+### Markets
+
+- Chain dropdown selector (populated from chains API).
+- Longitude/latitude coordinate inputs for geolocation.
+- Products listed inline via shared modal.
+
+### Products
+
+- Rich text editor for descriptions.
+- Multi-market pricing (price range display).
+- Category filtering.
+- Image upload with preview.
+
+### Dependencies
+
+| Dependency | Usage |
+|------------|-------|
+| `useDebounce` | Debounced search across all lists |
+| `useAxiosPrivate` | Authenticated API calls |
+| Images feature | Image gallery selector |
+| Material-UI | Tables, forms, dialogs, pagination |
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/client/src/features/chains/` | Chain list, search, form, query hooks |
+| `apps/client/src/features/markets/` | Market list, search, form, query hooks |
+| `apps/client/src/features/products/` | Product list, search, form, query hooks |

--- a/apps/docs/frontend/features/dashboard.md
+++ b/apps/docs/frontend/features/dashboard.md
@@ -1,0 +1,50 @@
+---
+title: Dashboard Feature
+---
+
+# Dashboard Feature
+
+## Public Summary
+
+Main admin navigation hub with tab-based layout routing to chains, markets, products, holidays, reports, insights, and feature flag management.
+
+## Internal Details
+
+### Files
+
+| File | Role |
+|------|------|
+| `Dashboard.jsx` | Root dashboard with tab navigation |
+| `DashboardHeader.jsx` | Header bar with title and theme toggle |
+| `DashboardLayout.jsx` | Layout wrapper with container and outlet |
+| `ChainsPage.jsx` | Chains management tab |
+| `MarketsPage.jsx` | Markets management tab |
+| `ProductsPage.jsx` | Products management tab |
+| `HolidaysPage.jsx` | Public holidays tab |
+| `ReportingPage.jsx` | Reports tab |
+
+### Route Structure
+
+| Route | Component | Description |
+|-------|-----------|-------------|
+| `/dashboard` | Dashboard | Redirects to `/dashboard/chains` |
+| `/dashboard/chains` | ChainsPage | Chain management |
+| `/dashboard/markets` | MarketsPage | Market management |
+| `/dashboard/products` | ProductsPage | Product management |
+| `/dashboard/holidays` | HolidaysPage | Holiday management |
+| `/dashboard/reporting` | ReportingPage | Report generation |
+| `/dashboard/insights` | InsightsPage | Analytics dashboard |
+| `/dashboard/features` | FeatureFlagsPage | Feature flag admin |
+
+### UI Pattern
+
+- Material-UI `Tabs` for section navigation.
+- Responsive: icon-only labels on mobile, full text on desktop.
+- `Outlet` pattern for nested route rendering.
+- Theme toggle in header via `themeStore`.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/client/src/features/dashboard/` | Dashboard layout, pages, header |

--- a/apps/docs/frontend/features/insights-reports-flags.md
+++ b/apps/docs/frontend/features/insights-reports-flags.md
@@ -1,0 +1,72 @@
+---
+title: Insights, Reports & Feature Flags
+---
+
+# Insights, Reports & Feature Flags
+
+## Public Summary
+
+Admin-facing analytics dashboard, async report generation UI, and runtime feature flag management.
+
+## Insights
+
+### Files
+
+- `InsightsPage.jsx` — Analytics dashboard with charts
+- `useInsightsQueries.js` — React Query hooks for analytics API
+- `useVisitorHeartbeat.js` — Passive page view tracking
+
+### UI Components
+
+- **Time range selector**: 30 / 90 / 365 day windows.
+- **Stat cards**: visitor count, page views, feature usage.
+- **Charts**: Line and bar charts via Recharts.
+- **CSV export**: admin-only data export button.
+- **Skeleton states**: loading placeholders for all data sections.
+
+### Visitor Heartbeat
+
+`useVisitorHeartbeat` sends a `POST /analytics/heartbeat` every 60 seconds while the user is on any page, tracking anonymous visitor sessions.
+
+## Reports
+
+### Files
+
+- `useReportQueries.js` — React Query hooks for report job lifecycle
+
+### UI Pattern
+
+- Create report → receive jobId (202 Accepted).
+- Poll job status until COMPLETED or terminal state.
+- Download CSV artifact when ready.
+- Cancel pending jobs.
+
+## Feature Flags
+
+### Files
+
+- `FeatureFlagsPage.jsx` — Admin toggle interface
+- `useFeatureFlagQueries.js` — React Query hooks
+
+### UI Pattern
+
+- Toggle switches for each flag.
+- Server-side sync on toggle.
+- `featureFlagStore` (Zustand) caches flags client-side for use across components.
+
+### Client-Side Usage
+
+```jsx
+const aiSearchEnabled = useFeatureFlag('ai-search');
+// Conditionally render AI search dialog
+```
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/client/src/features/insights/` | Analytics dashboard, visitor heartbeat |
+| `apps/client/src/features/reports/` | Report job lifecycle hooks |
+| `apps/client/src/features/feature-flags/` | Admin flag toggle UI |
+| `apps/client/src/store/featureFlagStore.js` | Client-side flag cache |
+| `apps/client/src/hooks/useFeatureFlag.js` | Feature flag check hook |

--- a/apps/docs/frontend/features/map.md
+++ b/apps/docs/frontend/features/map.md
@@ -1,0 +1,85 @@
+---
+title: Map Feature
+---
+
+# Map Feature
+
+## Public Summary
+
+Interactive MapLibre-based map showing supermarket locations, product search, multi-modal routing (walk, bike, car), market clustering, and AI-powered search dialog.
+
+## Internal Details
+
+### Files
+
+| File | Role |
+|------|------|
+| `MapPage.jsx` | Main map page with all controls |
+| `RoutingEngine.jsx` | OSRM route rendering |
+| `MarketMarkers.jsx` | Market pins with clustering |
+| `CreditMarker.jsx` | Map attribution |
+| `GlobalAISearchDialog.jsx` | AI-powered search overlay |
+| `RouteConfirmDialog.jsx` | Route mode selection dialog |
+| `LocateUser.jsx` | Geolocation button |
+| `UserDot.jsx` | User position indicator |
+| `MapProductInfoModal.jsx` | Market product detail modal |
+| `useMapPitch.js` | 3D pitch interaction hook |
+| `markerUtils.js` | Marker helper utilities |
+| `defaultVisibleChains.js` | Default chain filter config |
+| `markerColors.js` | Chain color mapping |
+| `markerPaths.js` | SVG marker path definitions |
+
+### Key Interactions
+
+```mermaid
+flowchart TD
+    A[MapPage] --> B[MarketMarkers]
+    A --> C[RoutingEngine]
+    A --> D[GlobalAISearchDialog]
+    A --> E[LocateUser]
+    B --> F[Supercluster Grouping]
+    F --> G[Click → MapProductInfoModal]
+    G --> H[Route to Market → RouteConfirmDialog]
+    H --> I[OSRM Route via RoutingEngine]
+    D --> J[AI Search Results]
+    J --> K[Select → Fly to Market]
+```
+
+### Clustering
+
+Uses **Supercluster** to group nearby markets at lower zoom levels, expanding to individual markers on zoom in. Performance optimization for hundreds of market locations.
+
+### Routing
+
+- **OSRM backend** at `/route/` for path calculation.
+- Three modes: walking, cycling, driving.
+- Route rendered as styled polyline on map.
+- Route confirmation dialog lets user pick mode before rendering.
+
+### Chain Filters
+
+- Users can toggle chain visibility (e.g., show only Vero markets).
+- Filter state persisted to `localStorage`.
+- Default visible chains configured in `defaultVisibleChains.js`.
+
+### Feature Flag Integration
+
+- `ai-search` flag gates the `GlobalAISearchDialog` component.
+- When disabled, only basic map browsing is available.
+
+### Dependencies
+
+| Dependency | Usage |
+|------------|-------|
+| MapLibre GL / react-map-gl | Map rendering |
+| Supercluster | Marker clustering |
+| OSRM | Routing engine |
+| `themeStore` | Dark/light map style |
+| `featureFlagStore` | AI search gate |
+| `useAuth` / `useLogout` | Auth state in header |
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/client/src/features/map/` | Pages, components, hooks, config, utils |

--- a/apps/docs/frontend/map-flows.md
+++ b/apps/docs/frontend/map-flows.md
@@ -1,0 +1,49 @@
+---
+title: Map And UX Flows
+---
+
+# Map And UX Flows
+
+## Public Summary
+
+Map experience combines market visualization, AI-assisted search, and route planning through OSRM-backed interactions.
+
+## Internal Details
+
+### Map Flow
+
+```mermaid
+sequenceDiagram
+  participant U as User
+  participant M as MapPage
+  participant S as Search Hooks
+  participant R as Routing Engine
+  participant A as API/OSRM
+  U->>M: Search/select market
+  M->>S: Query products/markets
+  S->>A: Fetch data
+  A-->>S: Result set
+  U->>R: Request route
+  R->>A: /route/* request
+  A-->>R: Route geometry
+  R-->>M: Render route
+```
+
+### Interaction Patterns
+
+- Clustered markers and responsive map behavior.
+- Modal-driven AI search entry.
+- Route confirmation workflow before navigation actions.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/client/src/features/map/pages/MapPage.jsx` | Main map page |
+| `apps/client/src/features/map/components/` | Map UI components (markers, routing, search) |
+| `apps/client/src/features/map/hooks/` | Map interaction hooks |
+| `apps/client/src/features/map/components/RoutingEngine.jsx` | OSRM route rendering component |
+
+## Risks and Trade-offs
+
+- Map-heavy pages can accumulate complexity quickly; keep feature boundaries strict and isolate routing/search concerns in hooks/services.

--- a/apps/docs/frontend/overview.md
+++ b/apps/docs/frontend/overview.md
@@ -1,0 +1,41 @@
+---
+title: Frontend Overview
+---
+
+# Frontend Overview
+
+## Public Summary
+
+The frontend is a React + Vite SPA organized by features, with route guards for protected areas and a combination of Zustand and TanStack Query for state.
+
+## Internal Details
+
+### Provider Composition
+
+```mermaid
+flowchart TD
+  Root[React Root] --> Query[QueryClientProvider]
+  Query --> Theme[ThemeProvider]
+  Theme --> Consent[ConsentGate]
+  Consent --> Router[BrowserRouter]
+  Router --> App[App Routes]
+```
+
+### Organization
+
+- Feature folders group pages, components, and hooks by domain.
+- Shared cross-cutting concerns are in hooks, store, and theme.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/client/src/entry.jsx` | Provider composition chain |
+| `apps/client/src/components/layout/App.jsx` | Route tree and guards |
+| `apps/client/src/features/` | Feature-based module directories |
+| `apps/client/src/store/` | Zustand stores (auth, theme, flags) |
+| `apps/client/src/hooks/` | Shared hooks (axios, debounce, feature flag) |
+
+## Risks and Trade-offs
+
+- Feature-first organization scales well for ownership, but requires consistency in naming and query key conventions.

--- a/apps/docs/frontend/routing-auth.md
+++ b/apps/docs/frontend/routing-auth.md
@@ -1,0 +1,44 @@
+---
+title: Routing And Access Control
+---
+
+# Routing And Access Control
+
+## Public Summary
+
+Routing separates public and protected areas. Access to dashboard routes is enforced by authentication wrappers.
+
+## Internal Details
+
+### Route Model
+
+- Public: landing/map and login.
+- Protected: dashboard feature routes behind auth guards.
+
+### Access Flow
+
+```mermaid
+flowchart LR
+  Request[Route Request] --> Persist[PersistLogin]
+  Persist --> Guard[RequireAuth]
+  Guard -->|Authorized| Dashboard[Dashboard Routes]
+  Guard -->|Unauthorized| Login[Login Route]
+```
+
+### Auth Recovery Behavior
+
+- Axios interceptor attempts token refresh on 403.
+- Guard components keep protected UI unavailable when auth is invalid.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/client/src/components/layout/App.jsx` | Route definitions |
+| `apps/client/src/features/auth/components/PersistLogin.jsx` | Silent token refresh wrapper |
+| `apps/client/src/features/auth/components/RequireAuth.jsx` | Auth guard for dashboard routes |
+| `apps/client/src/hooks/useAxiosPrivate.js` | Token interceptor with 403 retry |
+
+## Risks and Trade-offs
+
+- Auth coupling between guards and interceptor behavior requires clear testing to avoid redirect loops.

--- a/apps/docs/frontend/state-data.md
+++ b/apps/docs/frontend/state-data.md
@@ -1,0 +1,50 @@
+---
+title: State And Server Data
+---
+
+# State And Server Data
+
+## Public Summary
+
+The frontend separates local/client state (Zustand) from server state (TanStack Query), which keeps network caching and UI state concerns distinct.
+
+## Internal Details
+
+### State Responsibilities
+
+- Zustand: auth state, theme preferences, feature flag snapshots.
+- React Query: API data fetching, cache invalidation, and mutation lifecycle.
+
+### Data Flow
+
+```mermaid
+flowchart TD
+  UI[Feature UI] --> Hooks[Feature Query Hooks]
+  Hooks --> Axios[Axios Public/Private]
+  Axios --> API[Backend API]
+  API --> Hooks
+  Hooks --> Cache[React Query Cache]
+  Cache --> UI
+  UI --> Stores[Zustand Stores]
+```
+
+### Query Conventions
+
+- Query key factories are defined by feature.
+- Mutations invalidate domain and dependent keys.
+- Conditional queries use enabled predicates.
+
+## Source Anchors
+
+| Path | Relevance |
+|------|-----------|
+| `apps/client/src/store/authStore.js` | Auth state (Zustand, persisted) |
+| `apps/client/src/store/themeStore.js` | Theme preference (Zustand, persisted) |
+| `apps/client/src/store/featureFlagStore.js` | Feature flag cache (Zustand) |
+| `apps/client/src/features/products/hooks/useProductQueries.js` | Example query key factory |
+| `apps/client/src/features/chains/hooks/useChainQueries.js` | Example query key factory |
+| `apps/client/src/hooks/useAxiosPrivate.js` | Axios interceptor for auth |
+
+## Risks and Trade-offs
+
+- Cache invalidation strategy is explicit but can become repetitive across features without shared utility helpers.

--- a/apps/docs/index.md
+++ b/apps/docs/index.md
@@ -1,0 +1,55 @@
+---
+title: Student Obrok Documentation
+description: Full-stack technical documentation for architecture, backend, frontend, deployment, and design patterns.
+---
+
+# Student Obrok Documentation
+
+## Public Summary
+
+Student Obrok is a full-stack platform for market data ingestion, search, reporting, and route-aware exploration. The system combines:
+
+- A React client with feature-based modules.
+- An Express API with layered architecture and cron-driven data ingestion.
+- MongoDB for operational data.
+- OSRM for routing.
+- Docker-based environments for development and production.
+
+Use this site to understand how the system is built, operated, and extended.
+
+## Internal Details
+
+This documentation is written with two audiences in mind:
+
+- Public/quick readers who need a short explanation of each area.
+- Internal contributors who need implementation depth, trade-offs, and runbooks.
+
+Each major page follows the same structure:
+
+1. Public Summary
+2. Internal Details
+3. Source Anchors
+4. Risks and Trade-offs
+
+## Documentation Map
+
+- [System Architecture](/architecture/overview)
+- [Backend](/backend/overview)
+- [Frontend](/frontend/overview)
+- [Deployment](/deployment/overview)
+- [Design Pattern Catalog](/patterns/catalog)
+- [Contributing To Docs](/contributing/docs-process)
+
+## Current Scope (v1)
+
+- Full architecture map and cross-service flow documentation.
+- Backend module and operational flow documentation.
+- Frontend architecture and state/routing data flow documentation.
+- Deployment docs for local, production, and docs.obrok.net.
+- Pattern catalog and ADR baseline.
+
+## Out Of Scope (v1)
+
+- End-user product usage manuals.
+- Multi-language docs.
+- Auto-generated OpenAPI documentation portal.

--- a/apps/docs/overview/docs-charter.md
+++ b/apps/docs/overview/docs-charter.md
@@ -1,0 +1,47 @@
+---
+title: Documentation Charter
+---
+
+# Documentation Charter
+
+## Public Summary
+
+This charter defines how Student Obrok documentation is written so it stays consistent, useful, and maintainable.
+
+## Internal Details
+
+### Documentation Principles
+
+1. Prefer source-backed claims. Every technical statement should be traceable to implementation.
+2. Keep architecture current. Any change to flow, module boundaries, or deployment shape must include doc updates.
+3. Separate summary from depth. Pages start with a short public summary and then move into internal details.
+4. Explain trade-offs, not only design intent.
+
+### Page Template
+
+Each technical page should include these sections in order:
+
+1. Public Summary
+2. Internal Details
+3. Source Anchors
+4. Risks and Trade-offs
+5. Next Extension Points (optional)
+
+### Diagram Standard
+
+- Use Mermaid in v1 for architecture, lifecycle, and flow diagrams.
+- Prefer simple node names over abbreviations.
+- Keep one primary diagram per page to avoid visual noise.
+
+### Code Reference Standard
+
+- Reference implementation files by path.
+- Favor stable entry files (for example app/container/entrypoint) over volatile internals unless needed.
+- When documenting behavior, include at least one concrete route, hook, or service function path.
+
+### Documentation Ownership
+
+- Backend pages: backend maintainers.
+- Frontend pages: frontend maintainers.
+- Deployment pages: ops/release maintainers.
+- Pattern and ADR pages: architecture owners.

--- a/apps/docs/overview/how-to-read.md
+++ b/apps/docs/overview/how-to-read.md
@@ -1,0 +1,24 @@
+---
+title: How To Read This Site
+---
+
+# How To Read This Site
+
+## Public Summary
+
+Start with Architecture, then go to Backend or Frontend based on your role. Use Deployment if you are running environments or releases.
+
+## Internal Details
+
+### Suggested Reading Paths
+
+- New engineer: Architecture -> Backend/Frontend Overview -> Deployment Overview -> Pattern Catalog.
+- Backend maintainer: Backend pages -> Jobs/Cron/Reports -> Deployment runbooks.
+- Frontend maintainer: Frontend pages -> Routing/Auth -> State/Data -> Map flows.
+- Ops maintainer: Deployment pages -> Runbooks -> CI/CD workflow references.
+
+### How To Navigate Depth
+
+- If you only need high-level orientation, read only Public Summary sections.
+- If you need implementation behavior, read Internal Details and Source Anchors.
+- If you are making changes, review Risks and Trade-offs before editing code.

--- a/apps/docs/package-lock.json
+++ b/apps/docs/package-lock.json
@@ -1,0 +1,3943 @@
+{
+  "name": "student-obrok-docs",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "student-obrok-docs",
+      "devDependencies": {
+        "mermaid": "^11.14.0",
+        "vitepress": "^1.6.4",
+        "vitepress-plugin-mermaid": "^2.0.17"
+      }
+    },
+    "node_modules/@algolia/abtesting": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/@algolia/abtesting/-/abtesting-1.16.2.tgz",
+      "integrity": "sha512-n9s6bEV6imdtIEd+BGP7WkA4pEZ5YTdgQ05JQhHwWawHg3hyjpNwC0TShGz6zWhv+jfLDGA/6FFNbySFS0P9cw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/autocomplete-core": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-core/-/autocomplete-core-1.17.7.tgz",
+      "integrity": "sha512-BjiPOW6ks90UKl7TwMv7oNQMnzU+t/wk9mgIDi6b1tXpUek7MW0lbNOUHpvam9pe3lVCf4xPFT+lK7s+e+fs7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-plugin-algolia-insights": "1.17.7",
+        "@algolia/autocomplete-shared": "1.17.7"
+      }
+    },
+    "node_modules/@algolia/autocomplete-plugin-algolia-insights": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-plugin-algolia-insights/-/autocomplete-plugin-algolia-insights-1.17.7.tgz",
+      "integrity": "sha512-Jca5Ude6yUOuyzjnz57og7Et3aXjbwCSDf/8onLHSQgw1qW3ALl9mrMWaXb5FmPVkV3EtkD2F/+NkT6VHyPu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "search-insights": ">= 1 < 3"
+      }
+    },
+    "node_modules/@algolia/autocomplete-preset-algolia": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-preset-algolia/-/autocomplete-preset-algolia-1.17.7.tgz",
+      "integrity": "sha512-ggOQ950+nwbWROq2MOCIL71RE0DdQZsceqrg32UqnhDz8FlO9rL8ONHNsI2R1MH0tkgVIDKI/D0sMiUchsFdWA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-shared": "1.17.7"
+      },
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/autocomplete-shared": {
+      "version": "1.17.7",
+      "resolved": "https://registry.npmjs.org/@algolia/autocomplete-shared/-/autocomplete-shared-1.17.7.tgz",
+      "integrity": "sha512-o/1Vurr42U/qskRSuhBH+VKxMvkkUVTLU6WZQr+L5lGZZLYWyhdzWjW0iGXY7EkwRTjBqvN2EsR81yCTGV/kmg==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@algolia/client-search": ">= 4.9.1 < 6",
+        "algoliasearch": ">= 4.9.1 < 6"
+      }
+    },
+    "node_modules/@algolia/client-abtesting": {
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-abtesting/-/client-abtesting-5.50.2.tgz",
+      "integrity": "sha512-52iq0vHy1sphgnwoZyx5PmbEt8hsh+m7jD123LmBs6qy4GK7LbYZIeKd+nSnSipN2zvKRZ2zScS6h9PW3J7SXg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-analytics": {
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-analytics/-/client-analytics-5.50.2.tgz",
+      "integrity": "sha512-WpPIUg+cSG2aPUG0gS8Ko9DwRgbRPUZxJkolhL2aCsmSlcEEZT65dILrfg5ovcxtx0Kvr+xtBVsTMtsQWRtPDQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-common": {
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-common/-/client-common-5.50.2.tgz",
+      "integrity": "sha512-Gj2MgtArGcsr82kIqRlo6/dCAFjrs2gLByEqyRENuT7ugrSMFuqg1vDzeBjRL1t3EJEJCFtT0PLX3gB8A6Hq4Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-insights": {
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-insights/-/client-insights-5.50.2.tgz",
+      "integrity": "sha512-CUqoid5jDpmrc0oK3/xuZXFt6kwT0P9Lw7/nsM14YTr6puvmi+OUKmURpmebQF22S2vCG8L1DAoXXujxQUi/ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-personalization": {
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-personalization/-/client-personalization-5.50.2.tgz",
+      "integrity": "sha512-AndZWFoc0gbP5901OeQJ73BazgGgSGiBEba4ohdoJuZwHTO2Gio8Q4L1VLmytMBYcviVigB0iICToMvEJxI4ug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-query-suggestions": {
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-query-suggestions/-/client-query-suggestions-5.50.2.tgz",
+      "integrity": "sha512-NWoL+psEkz5dIzweaByVXuEB45wS8/rk0E0AhMMnaVJdVs7TcACPH2/OURm+N0xRDITkTHqCna823rd6Uqntdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/client-search": {
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/client-search/-/client-search-5.50.2.tgz",
+      "integrity": "sha512-ypSboUJ3XJoQz5DeDo82hCnrRuwq3q9ZdFhVKAik9TnZh1DvLqoQsrbBjXg7C7zQOtV/Qbge/HmyoV6V5L7MhQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/ingestion": {
+      "version": "1.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/ingestion/-/ingestion-1.50.2.tgz",
+      "integrity": "sha512-VlR2FRXLw2bCB94SQo6zxg/Qi+547aOji6Pb+dKE7h1DMCCY317St+OpjpmgzE+bT2O9ALIc0V4nVIBOd7Gy+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/monitoring": {
+      "version": "1.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/monitoring/-/monitoring-1.50.2.tgz",
+      "integrity": "sha512-Cmvfp2+qopzQt8OilU97rhLhosq7ZrB6uieok3EwFUqG/aalPg6DgfCmu0yJMrYe+KMC1qRVt1MTRAUwLknUMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/recommend": {
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/recommend/-/recommend-5.50.2.tgz",
+      "integrity": "sha512-jrkuyKoOM7dFWQ/6Y4hQAse2SC3L/RldG6GnPjMvAj65h+7Ubb51S0pKk4ofSStF0xm4LCNe0C4T6XX4nOFDiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-browser-xhr": {
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-browser-xhr/-/requester-browser-xhr-5.50.2.tgz",
+      "integrity": "sha512-4107YLJqCudPiBUlwnk6oTSUVwU7ab+qL1SfQGEDYI8DZH5gsf1ekPt9JykXRKYXf2IfouFL5GiCY/PHTFIjYw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-fetch": {
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-fetch/-/requester-fetch-5.50.2.tgz",
+      "integrity": "sha512-vOrd3MQpLgmf6wXAueTuZ/cA0W4uRwIHHaxNy3h+a6YcNn6bCV/gFdZuv3F13v593zRU2k5R75NmvRWLenvMrw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@algolia/requester-node-http": {
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/@algolia/requester-node-http/-/requester-node-http-5.50.2.tgz",
+      "integrity": "sha512-Mu9BFtgzGqDUy5Bcs2nMyoILIFSN13GKQaklKAFIsd0K3/9CpNyfeBc+/+Qs6mFZLlxG9qzullO7h+bjcTBuGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/client-common": "5.50.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/@antfu/install-pkg": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@antfu/install-pkg/-/install-pkg-1.1.0.tgz",
+      "integrity": "sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "package-manager-detector": "^1.3.0",
+        "tinyexec": "^1.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
+      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@braintree/sanitize-url": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-7.1.2.tgz",
+      "integrity": "sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@chevrotain/cst-dts-gen": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/cst-dts-gen/-/cst-dts-gen-12.0.0.tgz",
+      "integrity": "sha512-fSL4KXjTl7cDgf0B5Rip9Q05BOrYvkJV/RrBTE/bKDN096E4hN/ySpcBK5B24T76dlQ2i32Zc3PAE27jFnFrKg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/gast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/gast/-/gast-12.0.0.tgz",
+      "integrity": "sha512-1ne/m3XsIT8aEdrvT33so0GUC+wkctpUPK6zU9IlOyJLUbR0rg4G7ZiApiJbggpgPir9ERy3FRjT6T7lpgetnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@chevrotain/types": "12.0.0"
+      }
+    },
+    "node_modules/@chevrotain/regexp-to-ast": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/regexp-to-ast/-/regexp-to-ast-12.0.0.tgz",
+      "integrity": "sha512-p+EW9MaJwgaHguhoqwOtx/FwuGr+DnNn857sXWOi/mClXIkPGl3rn7hGNWvo31HA3vyeQxjqe+H36yZJwYU8cA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/types": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/types/-/types-12.0.0.tgz",
+      "integrity": "sha512-S+04vjFQKeuYw0/eW3U52LkAHQsB1ASxsPGsLPUyQgrZ2iNNibQrsidruDzjEX2JYfespXMG0eZmXlhA6z7nWA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@chevrotain/utils": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/@chevrotain/utils/-/utils-12.0.0.tgz",
+      "integrity": "sha512-lB59uJoaGIfOOL9knQqQRfhl9g7x8/wqFkp13zTdkRu1huG9kg6IJs1O8hqj9rs6h7orGxHJUKb+mX3rPbWGhA==",
+      "dev": true,
+      "license": "Apache-2.0"
+    },
+    "node_modules/@docsearch/css": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/css/-/css-3.8.2.tgz",
+      "integrity": "sha512-y05ayQFyUmCXze79+56v/4HpycYF3uFqB78pLPrSV5ZKAlDuIAAJNhaRi8tTdRNXh05yxX/TyNnzD6LwSM89vQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@docsearch/js": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/js/-/js-3.8.2.tgz",
+      "integrity": "sha512-Q5wY66qHn0SwA7Taa0aDbHiJvaFJLOJyHmooQ7y8hlwwQLQ/5WwCcoX0g7ii04Qi2DJlHsd0XXzJ8Ypw9+9YmQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@docsearch/react": "3.8.2",
+        "preact": "^10.0.0"
+      }
+    },
+    "node_modules/@docsearch/react": {
+      "version": "3.8.2",
+      "resolved": "https://registry.npmjs.org/@docsearch/react/-/react-3.8.2.tgz",
+      "integrity": "sha512-xCRrJQlTt8N9GU0DG4ptwHRkfnSnD/YpdeaXe02iKfqs97TkZJv60yE+1eq/tjPcVnTW8dP5qLP7itifFVV5eg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@algolia/autocomplete-core": "1.17.7",
+        "@algolia/autocomplete-preset-algolia": "1.17.7",
+        "@docsearch/css": "3.8.2",
+        "algoliasearch": "^5.14.2"
+      },
+      "peerDependencies": {
+        "@types/react": ">= 16.8.0 < 19.0.0",
+        "react": ">= 16.8.0 < 19.0.0",
+        "react-dom": ">= 16.8.0 < 19.0.0",
+        "search-insights": ">= 1 < 3"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        },
+        "search-insights": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@iconify-json/simple-icons": {
+      "version": "1.2.78",
+      "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.78.tgz",
+      "integrity": "sha512-I3lkNp0Qu7q2iZWkdcf/I2hqGhzK6qxdILh9T7XqowQrnpmG/BayDsiCf6PktDoWlW0U971xA5g+panm+NFrfQ==",
+      "dev": true,
+      "license": "CC0-1.0",
+      "dependencies": {
+        "@iconify/types": "*"
+      }
+    },
+    "node_modules/@iconify/types": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@iconify/types/-/types-2.0.0.tgz",
+      "integrity": "sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@iconify/utils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@iconify/utils/-/utils-3.1.0.tgz",
+      "integrity": "sha512-Zlzem1ZXhI1iHeeERabLNzBHdOa4VhQbqAcOQaMKuTuyZCpwKbC2R4Dd0Zo3g9EAc+Y4fiarO8HIHRAth7+skw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@antfu/install-pkg": "^1.1.0",
+        "@iconify/types": "^2.0.0",
+        "mlly": "^1.8.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@mermaid-js/mermaid-mindmap": {
+      "version": "9.3.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/mermaid-mindmap/-/mermaid-mindmap-9.3.0.tgz",
+      "integrity": "sha512-IhtYSVBBRYviH1Ehu8gk69pMDF8DSRqXBRDMWrEfHoaMruHeaP2DXA3PBnuwsMaCdPQhlUUcy/7DBLAEIXvCAw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@braintree/sanitize-url": "^6.0.0",
+        "cytoscape": "^3.23.0",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.1.0",
+        "d3": "^7.0.0",
+        "khroma": "^2.0.0",
+        "non-layered-tidy-tree-layout": "^2.0.2"
+      }
+    },
+    "node_modules/@mermaid-js/mermaid-mindmap/node_modules/@braintree/sanitize-url": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@braintree/sanitize-url/-/sanitize-url-6.0.4.tgz",
+      "integrity": "sha512-s3jaWicZd0pkP0jf5ysyHUI/RE7MHos6qlToFcGWXVp+ykHOy77OUMrfbgJ9it2C5bow7OIQwYYaHjk9XlBQ2A==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@mermaid-js/parser": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mermaid-js/parser/-/parser-1.1.0.tgz",
+      "integrity": "sha512-gxK9ZX2+Fex5zu8LhRQoMeMPEHbc73UKZ0FQ54YrQtUxE1VVhMwzeNtKRPAu5aXks4FasbMe4xB4bWrmq6Jlxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "langium": "^4.0.0"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.1.tgz",
+      "integrity": "sha512-d6FinEBLdIiK+1uACUttJKfgZREXrF0Qc2SmLII7W2AD8FfiZ9Wjd+rD/iRuf5s5dWrr1GgwXCvPqOuDquOowA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.1.tgz",
+      "integrity": "sha512-YjG/EwIDvvYI1YvYbHvDz/BYHtkY4ygUIXHnTdLhG+hKIQFBiosfWiACWortsKPKU/+dUwQQCKQM3qrDe8c9BA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.1.tgz",
+      "integrity": "sha512-mjCpF7GmkRtSJwon+Rq1N8+pI+8l7w5g9Z3vWj4T7abguC4Czwi3Yu/pFaLvA3TTeMVjnu3ctigusqWUfjZzvw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.1.tgz",
+      "integrity": "sha512-haZ7hJ1JT4e9hqkoT9R/19XW2QKqjfJVv+i5AGg57S+nLk9lQnJ1F/eZloRO3o9Scy9CM3wQ9l+dkXtcBgN5Ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.1.tgz",
+      "integrity": "sha512-czw90wpQq3ZsAVBlinZjAYTKduOjTywlG7fEeWKUA7oCmpA8xdTkxZZlwNJKWqILlq0wehoZcJYfBvOyhPTQ6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.1.tgz",
+      "integrity": "sha512-KVB2rqsxTHuBtfOeySEyzEOB7ltlB/ux38iu2rBQzkjbwRVlkhAGIEDiiYnO2kFOkJp+Z7pUXKyrRRFuFUKt+g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.1.tgz",
+      "integrity": "sha512-L+34Qqil+v5uC0zEubW7uByo78WOCIrBvci69E7sFASRl0X7b/MB6Cqd1lky/CtcSVTydWa2WZwFuWexjS5o6g==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.1.tgz",
+      "integrity": "sha512-n83O8rt4v34hgFzlkb1ycniJh7IR5RCIqt6mz1VRJD6pmhRi0CXdmfnLu9dIUS6buzh60IvACM842Ffb3xd6Gg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.1.tgz",
+      "integrity": "sha512-Nql7sTeAzhTAja3QXeAI48+/+GjBJ+QmAH13snn0AJSNL50JsDqotyudHyMbO2RbJkskbMbFJfIJKWA6R1LCJQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.1.tgz",
+      "integrity": "sha512-+pUymDhd0ys9GcKZPPWlFiZ67sTWV5UU6zOJat02M1+PiuSGDziyRuI/pPue3hoUwm2uGfxdL+trT6Z9rxnlMA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.1.tgz",
+      "integrity": "sha512-VSvgvQeIcsEvY4bKDHEDWcpW4Yw7BtlKG1GUT4FzBUlEKQK0rWHYBqQt6Fm2taXS+1bXvJT6kICu5ZwqKCnvlQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.1.tgz",
+      "integrity": "sha512-4LqhUomJqwe641gsPp6xLfhqWMbQV04KtPp7/dIp0nzPxAkNY1AbwL5W0MQpcalLYk07vaW9Kp1PBhdpZYYcEw==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.1.tgz",
+      "integrity": "sha512-tLQQ9aPvkBxOc/EUT6j3pyeMD6Hb8QF2BTBnCQWP/uu1lhc9AIrIjKnLYMEroIz/JvtGYgI9dF3AxHZNaEH0rw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.1.tgz",
+      "integrity": "sha512-RMxFhJwc9fSXP6PqmAz4cbv3kAyvD1etJFjTx4ONqFP9DkTkXsAMU4v3Vyc5BgzC+anz7nS/9tp4obsKfqkDHg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.1.tgz",
+      "integrity": "sha512-QKgFl+Yc1eEk6MmOBfRHYF6lTxiiiV3/z/BRrbSiW2I7AFTXoBFvdMEyglohPj//2mZS4hDOqeB0H1ACh3sBbg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.1.tgz",
+      "integrity": "sha512-RAjXjP/8c6ZtzatZcA1RaQr6O1TRhzC+adn8YZDnChliZHviqIjmvFwHcxi4JKPSDAt6Uhf/7vqcBzQJy0PDJg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.1.tgz",
+      "integrity": "sha512-wcuocpaOlaL1COBYiA89O6yfjlp3RwKDeTIA0hM7OpmhR1Bjo9j31G1uQVpDlTvwxGn2nQs65fBFL5UFd76FcQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-77PpsFQUCOiZR9+LQEFg9GClyfkNXj1MP6wRnzYs0EeWbPcHs02AXu4xuUbM1zhwn3wqaizle3AEYg5aeoohhg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.1.tgz",
+      "integrity": "sha512-5cIATbk5vynAjqqmyBjlciMJl1+R/CwX9oLk/EyiFXDWd95KpHdrOJT//rnUl4cUcskrd0jCCw3wpZnhIHdD9w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.1.tgz",
+      "integrity": "sha512-cl0w09WsCi17mcmWqqglez9Gk8isgeWvoUZ3WiJFYSR3zjBQc2J5/ihSjpl+VLjPqjQ/1hJRcqBfLjssREQILw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.1.tgz",
+      "integrity": "sha512-4Cv23ZrONRbNtbZa37mLSueXUCtN7MXccChtKpUnQNgF010rjrjfHx3QxkS2PI7LqGT5xXyYs1a7LbzAwT0iCA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.1.tgz",
+      "integrity": "sha512-i1okWYkA4FJICtr7KpYzFpRTHgy5jdDbZiWfvny21iIKky5YExiDXP+zbXzm3dUcFpkEeYNHgQ5fuG236JPq0g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.1.tgz",
+      "integrity": "sha512-u09m3CuwLzShA0EYKMNiFgcjjzwqtUMLmuCJLeZWjjOYA3IT2Di09KaxGBTP9xVztWyIWjVdsB2E9goMjZvTQg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.1.tgz",
+      "integrity": "sha512-k+600V9Zl1CM7eZxJgMyTUzmrmhB/0XZnF4pRypKAlAgxmedUA+1v9R+XOFv56W4SlHEzfeMtzujLJD22Uz5zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.1.tgz",
+      "integrity": "sha512-lWMnixq/QzxyhTV6NjQJ4SFo1J6PvOX8vUx5Wb4bBPsEb+8xZ89Bz6kOXpfXj9ak9AHTQVQzlgzBEc1SyM27xQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@shikijs/core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/core/-/core-2.5.0.tgz",
+      "integrity": "sha512-uu/8RExTKtavlpH7XqnVYBrfBkUc20ngXiX9NSrBhOVZYv/7XQRKUyhtkeflY5QsxC0GbJThCerruZfsUaSldg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4",
+        "hast-util-to-html": "^9.0.4"
+      }
+    },
+    "node_modules/@shikijs/engine-javascript": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-javascript/-/engine-javascript-2.5.0.tgz",
+      "integrity": "sha512-VjnOpnQf8WuCEZtNUdjjwGUbtAVKuZkVQ/5cHy/tojVVRIRtlWMYVjyWhxOmIq05AlSOv72z7hRNRGVBgQOl0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "oniguruma-to-es": "^3.1.0"
+      }
+    },
+    "node_modules/@shikijs/engine-oniguruma": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/engine-oniguruma/-/engine-oniguruma-2.5.0.tgz",
+      "integrity": "sha512-pGd1wRATzbo/uatrCIILlAdFVKdxImWJGQ5rFiB5VZi2ve5xj3Ax9jny8QvkaV93btQEwR/rSz5ERFpC5mKNIw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2"
+      }
+    },
+    "node_modules/@shikijs/langs": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/langs/-/langs-2.5.0.tgz",
+      "integrity": "sha512-Qfrrt5OsNH5R+5tJ/3uYBBZv3SuGmnRPejV9IlIbFH3HTGLDlkqgHymAlzklVmKBjAaVmkPkyikAV/sQ1wSL+w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/themes": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/themes/-/themes-2.5.0.tgz",
+      "integrity": "sha512-wGrk+R8tJnO0VMzmUExHR+QdSaPUl/NKs+a4cQQRWyoc3YFbUzuLEi/KWK1hj+8BfHRKm2jNhhJck1dfstJpiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/transformers": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/transformers/-/transformers-2.5.0.tgz",
+      "integrity": "sha512-SI494W5X60CaUwgi8u4q4m4s3YAFSxln3tzNjOSYqq54wlVgz0/NbbXEb3mdLbqMBztcmS7bVTaEd2w0qMmfeg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/types": "2.5.0"
+      }
+    },
+    "node_modules/@shikijs/types": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@shikijs/types/-/types-2.5.0.tgz",
+      "integrity": "sha512-ygl5yhxki9ZLNuNpPitBWvcy9fsSKKaRuO4BAlMyagszQidxcpLAr0qiW/q43DtSIDxO6hEbtYLiFZNXO/hdGw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/@shikijs/vscode-textmate": {
+      "version": "10.0.2",
+      "resolved": "https://registry.npmjs.org/@shikijs/vscode-textmate/-/vscode-textmate-10.0.2.tgz",
+      "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/web-bluetooth": {
+      "version": "0.0.21",
+      "resolved": "https://registry.npmjs.org/@types/web-bluetooth/-/web-bluetooth-0.0.21.tgz",
+      "integrity": "sha512-oIQLCGWtcFZy2JW77j9k8nHzAOpqMHLQejDA48XXMWH6tjCQHz5RCFz1bzsmROyL6PUm+LLnUiI4BCn221inxA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@upsetjs/venn.js": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@upsetjs/venn.js/-/venn.js-2.0.0.tgz",
+      "integrity": "sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1"
+      }
+    },
+    "node_modules/@vitejs/plugin-vue": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-vue/-/plugin-vue-5.2.4.tgz",
+      "integrity": "sha512-7Yx/SXSOcQq5HiiV3orevHUFn+pmMB4cgbEkDYgnkUWb0WfeQ/wa2yFv6D5ICiCQOVpjA7vYDXrC7AGO8yjDHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^5.0.0 || ^6.0.0",
+        "vue": "^3.2.25"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.32.tgz",
+      "integrity": "sha512-4x74Tbtqnda8s/NSD6e1Dr5p1c8HdMU5RWSjMSUzb8RTcUQqevDCxVAitcLBKT+ie3o0Dl9crc/S/opJM7qBGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/shared": "3.5.32",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.32.tgz",
+      "integrity": "sha512-ybHAu70NtiEI1fvAUz3oXZqkUYEe5J98GjMDpTGl5iHb0T15wQYLR4wE3h9xfuTNA+Cm2f4czfe8B4s+CCH57Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.32",
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.32.tgz",
+      "integrity": "sha512-8UYUYo71cP/0YHMO814TRZlPuUUw3oifHuMR7Wp9SNoRSrxRQnhMLNlCeaODNn6kNTJsjFoQ/kqIj4qGvya4Xg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.2",
+        "@vue/compiler-core": "3.5.32",
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.8",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.32.tgz",
+      "integrity": "sha512-Gp4gTs22T3DgRotZ8aA/6m2jMR+GMztvBXUBEUOYOcST+giyGWJ4WvFd7QLHBkzTxkfOt8IELKNdpzITLbA2rw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/devtools-api": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-api/-/devtools-api-7.7.9.tgz",
+      "integrity": "sha512-kIE8wvwlcZ6TJTbNeU2HQNtaxLx3a84aotTITUuL/4bzfPxzajGBOoqjMhwZJ8L9qFYDU/lAYMEEm11dnZOD6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-kit": "^7.7.9"
+      }
+    },
+    "node_modules/@vue/devtools-kit": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-kit/-/devtools-kit-7.7.9.tgz",
+      "integrity": "sha512-PyQ6odHSgiDVd4hnTP+aDk2X4gl2HmLDfiyEnn3/oV+ckFDuswRs4IbBT7vacMuGdwY/XemxBoh302ctbsptuA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/devtools-shared": "^7.7.9",
+        "birpc": "^2.3.0",
+        "hookable": "^5.5.3",
+        "mitt": "^3.0.1",
+        "perfect-debounce": "^1.0.0",
+        "speakingurl": "^14.0.1",
+        "superjson": "^2.2.2"
+      }
+    },
+    "node_modules/@vue/devtools-shared": {
+      "version": "7.7.9",
+      "resolved": "https://registry.npmjs.org/@vue/devtools-shared/-/devtools-shared-7.7.9.tgz",
+      "integrity": "sha512-iWAb0v2WYf0QWmxCGy0seZNDPdO3Sp5+u78ORnyeonS6MT4PC7VPrryX2BpMJrwlDeaZ6BD4vP4XKjK0SZqaeA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rfdc": "^1.4.1"
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.32.tgz",
+      "integrity": "sha512-/ORasxSGvZ6MN5gc+uE364SxFdJ0+WqVG0CENXaGW58TOCdrAW76WWaplDtECeS1qphvtBZtR+3/o1g1zL4xPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.32.tgz",
+      "integrity": "sha512-pDrXCejn4UpFDFmMd27AcJEbHaLemaE5o4pbb7sLk79SRIhc6/t34BQA7SGNgYtbMnvbF/HHOftYBgFJtUoJUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.32",
+        "@vue/shared": "3.5.32"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.32.tgz",
+      "integrity": "sha512-1CDVv7tv/IV13V8Nip1k/aaObVbWqRlVCVezTwx3K07p7Vxossp5JU1dcPNhJk3w347gonIUT9jQOGutyJrSVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.32",
+        "@vue/runtime-core": "3.5.32",
+        "@vue/shared": "3.5.32",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.32.tgz",
+      "integrity": "sha512-IOjm2+JQwRFS7W28HNuJeXQle9KdZbODFY7hFGVtnnghF51ta20EWAZJHX+zLGtsHhaU6uC9BGPV52KVpYryMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.32",
+        "@vue/shared": "3.5.32"
+      },
+      "peerDependencies": {
+        "vue": "3.5.32"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.32.tgz",
+      "integrity": "sha512-ksNyrmRQzWJJ8n3cRDuSF7zNNontuJg1YHnmWRJd2AMu8Ij2bqwiiri2lH5rHtYPZjj4STkNcgcmiQqlOjiYGg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@vueuse/core": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/core/-/core-12.8.2.tgz",
+      "integrity": "sha512-HbvCmZdzAu3VGi/pWYm5Ut+Kd9mn1ZHnn4L5G8kOQTPs/IwIAmJoBrmYk2ckLArgMXZj0AW3n5CAejLUO+PhdQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/web-bluetooth": "^0.0.21",
+        "@vueuse/metadata": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/integrations": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/integrations/-/integrations-12.8.2.tgz",
+      "integrity": "sha512-fbGYivgK5uBTRt7p5F3zy6VrETlV9RtZjBqd1/HxGdjdckBgBM4ugP8LHpjolqTj14TXTxSK1ZfgPbHYyGuH7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vueuse/core": "12.8.2",
+        "@vueuse/shared": "12.8.2",
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      },
+      "peerDependencies": {
+        "async-validator": "^4",
+        "axios": "^1",
+        "change-case": "^5",
+        "drauu": "^0.4",
+        "focus-trap": "^7",
+        "fuse.js": "^7",
+        "idb-keyval": "^6",
+        "jwt-decode": "^4",
+        "nprogress": "^0.2",
+        "qrcode": "^1.5",
+        "sortablejs": "^1",
+        "universal-cookie": "^7"
+      },
+      "peerDependenciesMeta": {
+        "async-validator": {
+          "optional": true
+        },
+        "axios": {
+          "optional": true
+        },
+        "change-case": {
+          "optional": true
+        },
+        "drauu": {
+          "optional": true
+        },
+        "focus-trap": {
+          "optional": true
+        },
+        "fuse.js": {
+          "optional": true
+        },
+        "idb-keyval": {
+          "optional": true
+        },
+        "jwt-decode": {
+          "optional": true
+        },
+        "nprogress": {
+          "optional": true
+        },
+        "qrcode": {
+          "optional": true
+        },
+        "sortablejs": {
+          "optional": true
+        },
+        "universal-cookie": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vueuse/metadata": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/metadata/-/metadata-12.8.2.tgz",
+      "integrity": "sha512-rAyLGEuoBJ/Il5AmFHiziCPdQzRt88VxR+Y/A/QhJ1EWtWqPBBAxTAFaSkviwEuOEZNtW8pvkPgoCZQ+HxqW1A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/@vueuse/shared": {
+      "version": "12.8.2",
+      "resolved": "https://registry.npmjs.org/@vueuse/shared/-/shared-12.8.2.tgz",
+      "integrity": "sha512-dznP38YzxZoNloI0qpEfpkms8knDtaoQ6Y/sfS0L7Yki4zh40LFHEhur0odJC6xTHG5dxWVPiUWBXn+wCG2s5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vue": "^3.5.13"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/acorn": {
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
+      "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "acorn": "bin/acorn"
+      },
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/algoliasearch": {
+      "version": "5.50.2",
+      "resolved": "https://registry.npmjs.org/algoliasearch/-/algoliasearch-5.50.2.tgz",
+      "integrity": "sha512-Tfp26yoNWurUjfgK4GOrVJQhSNXu9tJtHfFFNosgT2YClG+vPyUjX/gbC8rG39qLncnZg8Fj34iarQWpMkqefw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@algolia/abtesting": "1.16.2",
+        "@algolia/client-abtesting": "5.50.2",
+        "@algolia/client-analytics": "5.50.2",
+        "@algolia/client-common": "5.50.2",
+        "@algolia/client-insights": "5.50.2",
+        "@algolia/client-personalization": "5.50.2",
+        "@algolia/client-query-suggestions": "5.50.2",
+        "@algolia/client-search": "5.50.2",
+        "@algolia/ingestion": "1.50.2",
+        "@algolia/monitoring": "1.50.2",
+        "@algolia/recommend": "5.50.2",
+        "@algolia/requester-browser-xhr": "5.50.2",
+        "@algolia/requester-fetch": "5.50.2",
+        "@algolia/requester-node-http": "5.50.2"
+      },
+      "engines": {
+        "node": ">= 14.0.0"
+      }
+    },
+    "node_modules/birpc": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/birpc/-/birpc-2.9.0.tgz",
+      "integrity": "sha512-KrayHS5pBi69Xi9JmvoqrIgYGDkD6mcSe/i6YKi3w5kekCLzrX4+nawcXqrj2tIp50Kw/mT/s3p+GVK0A0sKxw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/chevrotain": {
+      "version": "12.0.0",
+      "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-12.0.0.tgz",
+      "integrity": "sha512-csJvb+6kEiQaqo1woTdSAuOWdN0WTLIydkKrBnS+V5gZz0oqBrp4kQ35519QgK6TpBThiG3V1vNSHlIkv4AglQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "@chevrotain/cst-dts-gen": "12.0.0",
+        "@chevrotain/gast": "12.0.0",
+        "@chevrotain/regexp-to-ast": "12.0.0",
+        "@chevrotain/types": "12.0.0",
+        "@chevrotain/utils": "12.0.0"
+      },
+      "engines": {
+        "node": ">=22.0.0"
+      }
+    },
+    "node_modules/chevrotain-allstar": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/chevrotain-allstar/-/chevrotain-allstar-0.4.1.tgz",
+      "integrity": "sha512-PvVJm3oGqrveUVW2Vt/eZGeiAIsJszYweUcYwcskg9e+IubNYKKD+rHHem7A6XVO22eDAL+inxNIGAzZ/VIWlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "lodash-es": "^4.17.21"
+      },
+      "peerDependencies": {
+        "chevrotain": "^12.0.0"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/commander": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-7.2.0.tgz",
+      "integrity": "sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/confbox": {
+      "version": "0.1.8",
+      "resolved": "https://registry.npmjs.org/confbox/-/confbox-0.1.8.tgz",
+      "integrity": "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/copy-anything": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/copy-anything/-/copy-anything-4.0.5.tgz",
+      "integrity": "sha512-7Vv6asjS4gMOuILabD3l739tsaxFQmC+a7pLZm02zyvs8p977bL3zEgq3yDk5rn9B0PbYgIv++jmHcuUab4RhA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-what": "^5.2.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/cose-base": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-1.0.3.tgz",
+      "integrity": "sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^1.0.0"
+      }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cytoscape": {
+      "version": "3.33.2",
+      "resolved": "https://registry.npmjs.org/cytoscape/-/cytoscape-3.33.2.tgz",
+      "integrity": "sha512-sj4HXd3DokGhzZAdjDejGvTPLqlt84vNFN8m7bGsOzDY5DyVcxIb2ejIXat2Iy7HxWhdT/N1oKyheJ5YdpsGuw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
+    "node_modules/cytoscape-cose-bilkent": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-cose-bilkent/-/cytoscape-cose-bilkent-4.1.0.tgz",
+      "integrity": "sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^1.0.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cytoscape-fcose/-/cytoscape-fcose-2.2.0.tgz",
+      "integrity": "sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cose-base": "^2.2.0"
+      },
+      "peerDependencies": {
+        "cytoscape": "^3.2.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/cose-base": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cose-base/-/cose-base-2.2.0.tgz",
+      "integrity": "sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "layout-base": "^2.0.0"
+      }
+    },
+    "node_modules/cytoscape-fcose/node_modules/layout-base": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-2.0.1.tgz",
+      "integrity": "sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/d3": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/d3/-/d3-7.9.0.tgz",
+      "integrity": "sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "3",
+        "d3-axis": "3",
+        "d3-brush": "3",
+        "d3-chord": "3",
+        "d3-color": "3",
+        "d3-contour": "4",
+        "d3-delaunay": "6",
+        "d3-dispatch": "3",
+        "d3-drag": "3",
+        "d3-dsv": "3",
+        "d3-ease": "3",
+        "d3-fetch": "3",
+        "d3-force": "3",
+        "d3-format": "3",
+        "d3-geo": "3",
+        "d3-hierarchy": "3",
+        "d3-interpolate": "3",
+        "d3-path": "3",
+        "d3-polygon": "3",
+        "d3-quadtree": "3",
+        "d3-random": "3",
+        "d3-scale": "4",
+        "d3-scale-chromatic": "3",
+        "d3-selection": "3",
+        "d3-shape": "3",
+        "d3-time": "3",
+        "d3-time-format": "4",
+        "d3-timer": "3",
+        "d3-transition": "3",
+        "d3-zoom": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-axis": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-axis/-/d3-axis-3.0.0.tgz",
+      "integrity": "sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-brush": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-brush/-/d3-brush-3.0.0.tgz",
+      "integrity": "sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "3",
+        "d3-transition": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-chord": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-chord/-/d3-chord-3.0.1.tgz",
+      "integrity": "sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-contour": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-contour/-/d3-contour-4.0.2.tgz",
+      "integrity": "sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "^3.2.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "delaunator": "5"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dsv": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dsv/-/d3-dsv-3.0.1.tgz",
+      "integrity": "sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "commander": "7",
+        "iconv-lite": "0.6",
+        "rw": "1"
+      },
+      "bin": {
+        "csv2json": "bin/dsv2json.js",
+        "csv2tsv": "bin/dsv2dsv.js",
+        "dsv2dsv": "bin/dsv2dsv.js",
+        "dsv2json": "bin/dsv2json.js",
+        "json2csv": "bin/json2dsv.js",
+        "json2dsv": "bin/json2dsv.js",
+        "json2tsv": "bin/json2dsv.js",
+        "tsv2csv": "bin/dsv2dsv.js",
+        "tsv2json": "bin/dsv2json.js"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-fetch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-fetch/-/d3-fetch-3.0.1.tgz",
+      "integrity": "sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dsv": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-force": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-3.0.0.tgz",
+      "integrity": "sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-quadtree": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-geo": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-3.1.1.tgz",
+      "integrity": "sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.5.0 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-hierarchy": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-3.1.2.tgz",
+      "integrity": "sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-path": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-3.1.0.tgz",
+      "integrity": "sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-polygon": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-polygon/-/d3-polygon-3.0.1.tgz",
+      "integrity": "sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-quadtree": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-3.0.1.tgz",
+      "integrity": "sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-random": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-random/-/d3-random-3.0.1.tgz",
+      "integrity": "sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-sankey": {
+      "version": "0.12.3",
+      "resolved": "https://registry.npmjs.org/d3-sankey/-/d3-sankey-0.12.3.tgz",
+      "integrity": "sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-array": "1 - 2",
+        "d3-shape": "^1.2.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-array": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-2.12.1.tgz",
+      "integrity": "sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "internmap": "^1.0.0"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/d3-path": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
+      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/d3-sankey/node_modules/d3-shape": {
+      "version": "1.3.7",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
+      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "d3-path": "1"
+      }
+    },
+    "node_modules/d3-sankey/node_modules/internmap": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-1.0.1.tgz",
+      "integrity": "sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-interpolate": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "dev": true,
+      "license": "ISC",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-shape": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-3.2.0.tgz",
+      "integrity": "sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-path": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/dagre-d3-es": {
+      "version": "7.0.14",
+      "resolved": "https://registry.npmjs.org/dagre-d3-es/-/dagre-d3-es-7.0.14.tgz",
+      "integrity": "sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "d3": "^7.9.0",
+        "lodash-es": "^4.17.21"
+      }
+    },
+    "node_modules/dayjs": {
+      "version": "1.11.20",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.20.tgz",
+      "integrity": "sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/delaunator": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/delaunator/-/delaunator-5.1.0.tgz",
+      "integrity": "sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "robust-predicates": "^3.0.2"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.0.tgz",
+      "integrity": "sha512-nolgK9JcaUXMSmW+j1yaSvaEaoXYHwWyGJlkoCTghc97KgGDDSnpoU/PlEnw63Ah+TGKFOyY+X5LnxaWbCSfXg==",
+      "dev": true,
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
+    },
+    "node_modules/emoji-regex-xs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex-xs/-/emoji-regex-xs-1.0.0.tgz",
+      "integrity": "sha512-LRlerrMYoIDrT6jgpeZ2YYl/L8EulRTt5hQcYjy5AInh7HWXKimpqx68aknBFpGL2+/IcogTcaydJEgaTmOpDg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/focus-trap": {
+      "version": "7.8.0",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.8.0.tgz",
+      "integrity": "sha512-/yNdlIkpWbM0ptxno3ONTuf+2g318kh2ez3KSeZN5dZ8YC6AAmgeWz+GasYYiBJPFaYcSAPeu4GfhUaChzIJXA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "tabbable": "^6.4.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hachure-fill": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/hachure-fill/-/hachure-fill-0.5.2.tgz",
+      "integrity": "sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hookable": {
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/hookable/-/hookable-5.5.3.tgz",
+      "integrity": "sha512-Yc+BQe8SvoXH1643Qez1zqLRmbA5rCL+sSmk6TVos0LWVfNIB7PGncdlId77WzLGSIB5KaWgTaNTs2lNVEI6VQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/is-what": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/is-what/-/is-what-5.5.0.tgz",
+      "integrity": "sha512-oG7cgbmg5kLYae2N5IVd3jm2s+vldjxJzK1pcu9LfpGuQ93MQSzo0okvRna+7y5ifrD+20FE8FvjusyGaz14fw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/mesqueeb"
+      }
+    },
+    "node_modules/katex": {
+      "version": "0.16.45",
+      "resolved": "https://registry.npmjs.org/katex/-/katex-0.16.45.tgz",
+      "integrity": "sha512-pQpZbdBu7wCTmQUh7ufPmLr0pFoObnGUoL/yhtwJDgmmQpbkg/0HSVti25Fu4rmd1oCR6NGWe9vqTWuWv3GcNA==",
+      "dev": true,
+      "funding": [
+        "https://opencollective.com/katex",
+        "https://github.com/sponsors/katex"
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "commander": "^8.3.0"
+      },
+      "bin": {
+        "katex": "cli.js"
+      }
+    },
+    "node_modules/katex/node_modules/commander": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+      "integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/khroma": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/khroma/-/khroma-2.1.0.tgz",
+      "integrity": "sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==",
+      "dev": true
+    },
+    "node_modules/langium": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/langium/-/langium-4.2.2.tgz",
+      "integrity": "sha512-JUshTRAfHI4/MF9dH2WupvjSXyn8JBuUEWazB8ZVJUtXutT0doDlAv1XKbZ1Pb5sMexa8FF4CFBc0iiul7gbUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@chevrotain/regexp-to-ast": "~12.0.0",
+        "chevrotain": "~12.0.0",
+        "chevrotain-allstar": "~0.4.1",
+        "vscode-languageserver": "~9.0.1",
+        "vscode-languageserver-textdocument": "~1.0.11",
+        "vscode-uri": "~3.1.0"
+      },
+      "engines": {
+        "node": ">=20.10.0",
+        "npm": ">=10.2.3"
+      }
+    },
+    "node_modules/layout-base": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/layout-base/-/layout-base-1.0.2.tgz",
+      "integrity": "sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lodash-es": {
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/mark.js": {
+      "version": "8.11.1",
+      "resolved": "https://registry.npmjs.org/mark.js/-/mark.js-8.11.1.tgz",
+      "integrity": "sha512-1I+1qpDt4idfgLQG+BNWmrqku+7/2bi5nLf4YwF8y8zXvmfiTBY3PV3ZibfrjBueCByROpuBjLLFCajqkgYoLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/marked": {
+      "version": "16.4.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-16.4.2.tgz",
+      "integrity": "sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mermaid": {
+      "version": "11.14.0",
+      "resolved": "https://registry.npmjs.org/mermaid/-/mermaid-11.14.0.tgz",
+      "integrity": "sha512-GSGloRsBs+JINmmhl0JDwjpuezCsHB4WGI4NASHxL3fHo3o/BRXTxhDLKnln8/Q0lRFRyDdEjmk1/d5Sn1Xz8g==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@braintree/sanitize-url": "^7.1.1",
+        "@iconify/utils": "^3.0.2",
+        "@mermaid-js/parser": "^1.1.0",
+        "@types/d3": "^7.4.3",
+        "@upsetjs/venn.js": "^2.0.0",
+        "cytoscape": "^3.33.1",
+        "cytoscape-cose-bilkent": "^4.1.0",
+        "cytoscape-fcose": "^2.2.0",
+        "d3": "^7.9.0",
+        "d3-sankey": "^0.12.3",
+        "dagre-d3-es": "7.0.14",
+        "dayjs": "^1.11.19",
+        "dompurify": "^3.3.1",
+        "katex": "^0.16.25",
+        "khroma": "^2.1.0",
+        "lodash-es": "^4.17.23",
+        "marked": "^16.3.0",
+        "roughjs": "^4.6.6",
+        "stylis": "^4.3.6",
+        "ts-dedent": "^2.2.0",
+        "uuid": "^11.1.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mitt": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mitt/-/mitt-3.0.1.tgz",
+      "integrity": "sha512-vKivATfr97l2/QBCYAkXYDbrIWPM2IIKEl7YPhjCvKlG3kE2gm+uBo6nEXK3M5/Ffh/FLpKExzOQ3JJoJGFKBw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/mlly": {
+      "version": "1.8.2",
+      "resolved": "https://registry.npmjs.org/mlly/-/mlly-1.8.2.tgz",
+      "integrity": "sha512-d+ObxMQFmbt10sretNDytwt85VrbkhhUA/JBGm1MPaWJ65Cl4wOgLaB1NYvJSZ0Ef03MMEU/0xpPMXUIQ29UfA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "acorn": "^8.16.0",
+        "pathe": "^2.0.3",
+        "pkg-types": "^1.3.1",
+        "ufo": "^1.6.3"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/non-layered-tidy-tree-layout": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/non-layered-tidy-tree-layout/-/non-layered-tidy-tree-layout-2.0.2.tgz",
+      "integrity": "sha512-gkXMxRzUH+PB0ax9dUN0yYF0S25BqeAYqhgMaLUFmpXLEk7Fcu8f4emJuOAY0V8kjDICxROIKsTAKsV/v355xw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/oniguruma-to-es": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/oniguruma-to-es/-/oniguruma-to-es-3.1.1.tgz",
+      "integrity": "sha512-bUH8SDvPkH3ho3dvwJwfonjlQ4R80vjyvrU8YpxuROddv55vAEJrTuCuCVUhhsHbtlD9tGGbaNApGQckXhS8iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex-xs": "^1.0.0",
+        "regex": "^6.0.1",
+        "regex-recursion": "^6.0.2"
+      }
+    },
+    "node_modules/package-manager-detector": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/package-manager-detector/-/package-manager-detector-1.6.0.tgz",
+      "integrity": "sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/path-data-parser": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/path-data-parser/-/path-data-parser-0.1.0.tgz",
+      "integrity": "sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/perfect-debounce": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/perfect-debounce/-/perfect-debounce-1.0.0.tgz",
+      "integrity": "sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/pkg-types": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/pkg-types/-/pkg-types-1.3.1.tgz",
+      "integrity": "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "confbox": "^0.1.8",
+        "mlly": "^1.7.4",
+        "pathe": "^2.0.1"
+      }
+    },
+    "node_modules/points-on-curve": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/points-on-curve/-/points-on-curve-0.2.0.tgz",
+      "integrity": "sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/points-on-path": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/points-on-path/-/points-on-path-0.2.1.tgz",
+      "integrity": "sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "path-data-parser": "0.1.0",
+        "points-on-curve": "0.2.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/preact": {
+      "version": "10.29.1",
+      "resolved": "https://registry.npmjs.org/preact/-/preact-10.29.1.tgz",
+      "integrity": "sha512-gQCLc/vWroE8lIpleXtdJhTFDogTdZG9AjMUpVkDf2iTCNwYNWA+u16dL41TqUDJO4gm2IgrcMv3uTpjd4Pwmg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/preact"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/regex": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/regex/-/regex-6.1.0.tgz",
+      "integrity": "sha512-6VwtthbV4o/7+OaAF9I5L5V3llLEsoPyq9P1JVXkedTP33c7MfCG0/5NOPcSJn0TzXcG9YUrR0gQSWioew3LDg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-recursion": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/regex-recursion/-/regex-recursion-6.0.2.tgz",
+      "integrity": "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regex-utilities": "^2.3.0"
+      }
+    },
+    "node_modules/regex-utilities": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/regex-utilities/-/regex-utilities-2.3.0.tgz",
+      "integrity": "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/robust-predicates": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/robust-predicates/-/robust-predicates-3.0.3.tgz",
+      "integrity": "sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==",
+      "dev": true,
+      "license": "Unlicense"
+    },
+    "node_modules/rollup": {
+      "version": "4.60.1",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
+      "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.1",
+        "@rollup/rollup-android-arm64": "4.60.1",
+        "@rollup/rollup-darwin-arm64": "4.60.1",
+        "@rollup/rollup-darwin-x64": "4.60.1",
+        "@rollup/rollup-freebsd-arm64": "4.60.1",
+        "@rollup/rollup-freebsd-x64": "4.60.1",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.1",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.1",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.1",
+        "@rollup/rollup-linux-arm64-musl": "4.60.1",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.1",
+        "@rollup/rollup-linux-loong64-musl": "4.60.1",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.1",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.1",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.1",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.1",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-gnu": "4.60.1",
+        "@rollup/rollup-linux-x64-musl": "4.60.1",
+        "@rollup/rollup-openbsd-x64": "4.60.1",
+        "@rollup/rollup-openharmony-arm64": "4.60.1",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.1",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.1",
+        "@rollup/rollup-win32-x64-gnu": "4.60.1",
+        "@rollup/rollup-win32-x64-msvc": "4.60.1",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/roughjs": {
+      "version": "4.6.6",
+      "resolved": "https://registry.npmjs.org/roughjs/-/roughjs-4.6.6.tgz",
+      "integrity": "sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "hachure-fill": "^0.5.2",
+        "path-data-parser": "^0.1.0",
+        "points-on-curve": "^0.2.0",
+        "points-on-path": "^0.2.1"
+      }
+    },
+    "node_modules/rw": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
+      "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
+      "dev": true,
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/search-insights": {
+      "version": "2.17.3",
+      "resolved": "https://registry.npmjs.org/search-insights/-/search-insights-2.17.3.tgz",
+      "integrity": "sha512-RQPdCYTa8A68uM2jwxoY842xDhvx3E5LFL1LxvxCNMev4o5mLuokczhzjAgGwUZBAmOKZknArSxLKmXtIi2AxQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/shiki": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/shiki/-/shiki-2.5.0.tgz",
+      "integrity": "sha512-mI//trrsaiCIPsja5CNfsyNOqgAZUb6VpJA+340toL42UpzQlXpwRV9nch69X6gaUxrr9kaOOa6e3y3uAkGFxQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@shikijs/core": "2.5.0",
+        "@shikijs/engine-javascript": "2.5.0",
+        "@shikijs/engine-oniguruma": "2.5.0",
+        "@shikijs/langs": "2.5.0",
+        "@shikijs/themes": "2.5.0",
+        "@shikijs/types": "2.5.0",
+        "@shikijs/vscode-textmate": "^10.0.2",
+        "@types/hast": "^3.0.4"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/speakingurl": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/speakingurl/-/speakingurl-14.0.1.tgz",
+      "integrity": "sha512-1POYv7uv2gXoyGFpBCmpDVSNV74IfsWlDW216UPjbWufNf+bSU6GdbDsxdcxtfwb4xlI3yxzOTKClUosxARYrQ==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stylis": {
+      "version": "4.3.6",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.3.6.tgz",
+      "integrity": "sha512-yQ3rwFWRfwNUY7H5vpU0wfdkNSnvnJinhF9830Swlaxl03zsOjCfmX0ugac+3LtK0lYSgwL/KXc8oYL3mG4YFQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/superjson": {
+      "version": "2.2.6",
+      "resolved": "https://registry.npmjs.org/superjson/-/superjson-2.2.6.tgz",
+      "integrity": "sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "copy-anything": "^4"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tabbable": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.4.0.tgz",
+      "integrity": "sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.1.tgz",
+      "integrity": "sha512-VKS/ZaQhhkKFMANmAOhhXVoIfBXblQxGX1myCQ2faQrfmobMftXeJPcZGp0gS07ocvGJWDLZGyOZDadDBqYIJg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ts-dedent": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/ts-dedent/-/ts-dedent-2.2.0.tgz",
+      "integrity": "sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.10"
+      }
+    },
+    "node_modules/ufo": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
+      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
+      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress": {
+      "version": "1.6.4",
+      "resolved": "https://registry.npmjs.org/vitepress/-/vitepress-1.6.4.tgz",
+      "integrity": "sha512-+2ym1/+0VVrbhNyRoFFesVvBvHAVMZMK0rw60E3X/5349M1GuVdKeazuksqopEdvkKwKGs21Q729jX81/bkBJg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@docsearch/css": "3.8.2",
+        "@docsearch/js": "3.8.2",
+        "@iconify-json/simple-icons": "^1.2.21",
+        "@shikijs/core": "^2.1.0",
+        "@shikijs/transformers": "^2.1.0",
+        "@shikijs/types": "^2.1.0",
+        "@types/markdown-it": "^14.1.2",
+        "@vitejs/plugin-vue": "^5.2.1",
+        "@vue/devtools-api": "^7.7.0",
+        "@vue/shared": "^3.5.13",
+        "@vueuse/core": "^12.4.0",
+        "@vueuse/integrations": "^12.4.0",
+        "focus-trap": "^7.6.4",
+        "mark.js": "8.11.1",
+        "minisearch": "^7.1.1",
+        "shiki": "^2.1.0",
+        "vite": "^5.4.14",
+        "vue": "^3.5.13"
+      },
+      "bin": {
+        "vitepress": "bin/vitepress.js"
+      },
+      "peerDependencies": {
+        "markdown-it-mathjax3": "^4",
+        "postcss": "^8"
+      },
+      "peerDependenciesMeta": {
+        "markdown-it-mathjax3": {
+          "optional": true
+        },
+        "postcss": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vitepress-plugin-mermaid": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/vitepress-plugin-mermaid/-/vitepress-plugin-mermaid-2.0.17.tgz",
+      "integrity": "sha512-IUzYpwf61GC6k0XzfmAmNrLvMi9TRrVRMsUyCA8KNXhg/mQ1VqWnO0/tBVPiX5UoKF1mDUwqn5QV4qAJl6JnUg==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "@mermaid-js/mermaid-mindmap": "^9.3.0"
+      },
+      "peerDependencies": {
+        "mermaid": "10 || 11",
+        "vitepress": "^1.0.0 || ^1.0.0-alpha"
+      }
+    },
+    "node_modules/vscode-jsonrpc": {
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/vscode-languageserver": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver/-/vscode-languageserver-9.0.1.tgz",
+      "integrity": "sha512-woByF3PDpkHFUreUa7Hos7+pUWdeWMXRd26+ZX2A8cFx6v/JPTtd4/uN0/jB6XQHYaOlHbio03NTHCqrgG5n7g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-languageserver-protocol": "3.17.5"
+      },
+      "bin": {
+        "installServerIntoExtension": "bin/installServerIntoExtension"
+      }
+    },
+    "node_modules/vscode-languageserver-protocol": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
+      }
+    },
+    "node_modules/vscode-languageserver-textdocument": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-textdocument/-/vscode-languageserver-textdocument-1.0.12.tgz",
+      "integrity": "sha512-cxWNPesCnQCcMPeenjKKsOCKQZ/L6Tv19DTRIGuLWe32lyzWhihGVJ/rcckZXJxfdKCFvRLS3fpBIsV/ZGX4zA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-languageserver-types": {
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue": {
+      "version": "3.5.32",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.32.tgz",
+      "integrity": "sha512-vM4z4Q9tTafVfMAK7IVzmxg34rSzTFMyIe0UUEijUCkn9+23lj0WRfA83dg7eQZIUlgOSGrkViIaCfqSAUXsMw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.32",
+        "@vue/compiler-sfc": "3.5.32",
+        "@vue/runtime-dom": "3.5.32",
+        "@vue/server-renderer": "3.5.32",
+        "@vue/shared": "3.5.32"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    }
+  }
+}

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "student-obrok-docs",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "docs:dev": "vitepress dev .",
+    "docs:build": "vitepress build .",
+    "docs:preview": "vitepress preview ."
+  },
+  "devDependencies": {
+    "mermaid": "^11.14.0",
+    "vitepress": "^1.6.4",
+    "vitepress-plugin-mermaid": "^2.0.17"
+  }
+}

--- a/apps/docs/patterns/adrs.md
+++ b/apps/docs/patterns/adrs.md
@@ -1,0 +1,46 @@
+---
+title: Architecture Decision Records
+---
+
+# Architecture Decision Records
+
+## Public Summary
+
+This page tracks major architectural decisions and the reasons behind them.
+
+## Internal Details
+
+## ADR-001: Layered Express Architecture
+
+- Status: Accepted
+- Context: Feature growth required clear responsibility boundaries.
+- Decision: Use controller -> service -> repository -> model layering.
+- Consequences: Better testability and readability, with moderate boilerplate cost.
+
+## ADR-002: Feature-Based Frontend Structure
+
+- Status: Accepted
+- Context: Dashboard and map functionality expanded into many domains.
+- Decision: Organize frontend by feature folders with per-feature hooks and pages.
+- Consequences: Better ownership and modular navigation, with risk of duplicated helper logic.
+
+## ADR-003: Self-Hosted OSRM Routing
+
+- Status: Accepted
+- Context: Need for route operations without per-request third-party map cost.
+- Decision: Run OSRM as a dedicated service with preprocessed map data.
+- Consequences: Better control and cost profile, increased infrastructure/data maintenance.
+
+## ADR-004: Docker Compose For Dev And Prod
+
+- Status: Accepted
+- Context: Need reproducible environments across onboarding and deployment.
+- Decision: Maintain compose definitions for development and production.
+- Consequences: High reproducibility, but production orchestration remains single-host.
+
+## ADR-005: Feature Flags For Search Features
+
+- Status: Accepted
+- Context: AI/embedding features carry cost and operational variability.
+- Decision: Gate behavior through feature flags in backend and frontend.
+- Consequences: Safer rollout, requires discipline to remove stale flags.

--- a/apps/docs/patterns/catalog.md
+++ b/apps/docs/patterns/catalog.md
@@ -1,0 +1,27 @@
+---
+title: Pattern Catalog
+---
+
+# Pattern Catalog
+
+## Public Summary
+
+Student Obrok uses explicit, practical patterns to keep modules understandable and evolvable across backend and frontend.
+
+## Internal Details
+
+| Pattern | Purpose | Where Used |
+| --- | --- | --- |
+| Dependency Injection Container | Central composition root for services/controllers | apps/server/src/container.js |
+| Controller-Service-Repository | Separation of transport, business, and persistence concerns | apps/server/src/modules/* |
+| Strategy + Registry | Plug-in market scraper implementations | apps/server/src/modules/scraper/markets and apps/server/src/modules/scraper/scraper.registry.js |
+| Middleware Pipeline | Ordered cross-cutting HTTP concerns | apps/server/src/app.js |
+| Feature Flag Gate | Runtime enablement of risky/experimental features | apps/server/src/modules/feature-flag and apps/client/src/store/featureFlagStore.js |
+| Query Key Factory | Predictable cache keys and invalidation | apps/client/src/features/*/hooks |
+| Axios Interceptor Retry | Access token refresh and replay | apps/client/src/hooks/useAxiosPrivate.js |
+| Persisted UI Store | Client preferences across sessions | apps/client/src/store/themeStore.js |
+
+## Risks and Trade-offs
+
+- Pattern consistency reduces cognitive load, but drift appears quickly if new modules skip standard layering.
+- Some patterns are manually enforced; automated linting or architecture checks can further reduce drift.

--- a/apps/docs/public/logo.svg
+++ b/apps/docs/public/logo.svg
@@ -1,0 +1,4 @@
+<svg width="256" height="256" viewBox="0 0 256 256" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="256" height="256" rx="32" fill="#1A1F2E"/>
+  <path d="M52 168V88h24l44 52 44-52h24v80h-22v-46l-43 50h-10l-43-50v46H52Z" fill="#F6F7FB"/>
+</svg>

--- a/apps/nginx/nginx.conf
+++ b/apps/nginx/nginx.conf
@@ -15,7 +15,7 @@ http {
     # Redirect all HTTP traffic to HTTPS
     server {
         listen 80 default_server;
-        server_name obrok.net;
+        server_name obrok.net docs.obrok.net;
 
         location ~ /.well-known/acme-challenge/ {
             root /var/www/certbot;
@@ -71,6 +71,35 @@ http {
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
+        }
+    }
+
+    # docs.obrok.net – VitePress static documentation
+    server {
+        listen 443 ssl;
+        http2 on;
+        server_name docs.obrok.net;
+
+        ssl_certificate /etc/letsencrypt/live/obrok.net/fullchain.pem;
+        ssl_certificate_key /etc/letsencrypt/live/obrok.net/privkey.pem;
+        ssl_protocols TLSv1.2 TLSv1.3;
+        ssl_prefer_server_ciphers on;
+
+        add_header Strict-Transport-Security "max-age=31536000; includeSubDomains" always;
+        add_header X-Frame-Options SAMEORIGIN;
+        add_header X-Content-Type-Options nosniff;
+
+        root /var/www/docs;
+        index index.html;
+
+        location / {
+            try_files $uri $uri.html $uri/ =404;
+            error_page 404 /404.html;
+        }
+
+        location ~* ^/assets/ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
         }
     }
 }

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -29,6 +29,21 @@ services:
     networks:
       - obrok_net
 
+  docs:
+    container_name: obrok_docs
+    build:
+      dockerfile: Dockerfile.dev
+      context: ./apps/docs
+    volumes:
+      - docs_node_modules:/app/node_modules
+      - ./apps/docs:/app
+    environment:
+      NODE_ENV: development
+    ports:
+      - 5173:5173
+    networks:
+      - obrok_net
+
   api:
     container_name: obrok_api
     build:
@@ -79,3 +94,4 @@ volumes:
   student_obrok_db:
   client_node_modules:
   server_node_modules:
+  docs_node_modules:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -9,6 +9,7 @@ services:
       - ./apps/nginx/nginx.conf:/etc/nginx/nginx.conf
       - ./data/certbot/conf:/etc/letsencrypt
       - ./data/certbot/www:/var/www/certbot
+      - ./apps/docs/.vitepress/dist:/var/www/docs:ro
     environment:
       NODE_ENV: production
     ports:

--- a/init-ssl.sh
+++ b/init-ssl.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e # Stops the script immediately if Docker fails to build
 
-domains=(obrok.net)
+domains=(obrok.net docs.obrok.net)
 rsa_key_size=4096
 data_path="./data/certbot"
 email="your-email@example.com" # REPLACE WITH YOUR EMAIL


### PR DESCRIPTION
## Summary

This PR adds a full VitePress documentation site for Student Obrok, wires docs into local and production infrastructure, and rewrites the README into a clearer open source repo style.

## What changed

- added a new docs site under `apps/docs`
- documented architecture, backend modules, frontend flows, deployment, patterns, and docs process
- enabled Mermaid diagram rendering in VitePress
- audited and corrected diagrams and source anchors across the docs
- added a docs service to `docker-compose.dev.yml`
- mounted built docs into production through `docker-compose.prod.yml`
- added `docs.obrok.net` nginx routing and SSL bootstrap support
- added docs CI validation and docs build during deployment
- updated the README to better describe the product, local setup, docs, and deployment flow

## Notes

The README was also refined to better reflect the actual product behavior:
- product data is scraped from nearby market chains
- users can search ingredients directly
- meal searches use AI recipe decomposition to resolve into ingredient lists tied to real markets
- users can route to selected markets through OSRM

## Validation

- ran `npm run docs:build` in `apps/docs`
- verified the docs build completed successfully
- checked for workspace errors after the docs cleanup pass

## Impact

This makes the project easier to understand, easier to run locally, and better prepared for public-facing documentation and production docs hosting.