### PR TITLE
fix: token refresh race condition, cluster gradient, and orphaned report files

### DIFF
--- a/apps/client/src/api/fetch.js
+++ b/apps/client/src/api/fetch.js
@@ -23,18 +23,32 @@ async function handleResponse(res, raw) {
 
 export async function fetchPublic(path, options = {}) {
   const { raw, ...fetchOptions } = options;
+  const headers = new Headers(fetchOptions.headers);
+  if (!headers.has("Content-Type") && !(fetchOptions.body instanceof FormData)) {
+    headers.set("Content-Type", "application/json");
+  }
   const res = await fetch(`${BASE_API_URL}${path}`, {
     credentials: "include",
     ...fetchOptions,
+    headers,
   });
   return handleResponse(res, raw);
 }
 
+let refreshPromise = null;
+
 async function refreshAccessToken() {
-  const data = await fetchPublic("/refresh");
-  const { setAuth } = useAuthStore.getState();
-  setAuth((prev) => ({ ...prev, accessToken: data.accessToken }));
-  return data.accessToken;
+  if (refreshPromise) return refreshPromise;
+  refreshPromise = fetchPublic("/refresh")
+    .then((data) => {
+      const { setAuth } = useAuthStore.getState();
+      setAuth((prev) => ({ ...prev, accessToken: data.accessToken }));
+      return data.accessToken;
+    })
+    .finally(() => {
+      refreshPromise = null;
+    });
+  return refreshPromise;
 }
 
 export async function fetchPrivate(path, options = {}) {

--- a/apps/client/src/features/auth/pages/Login.jsx
+++ b/apps/client/src/features/auth/pages/Login.jsx
@@ -33,7 +33,6 @@ const Login = () => {
     try {
       const data = await fetchPublic("/login", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ username, password }),
       });
 

--- a/apps/client/src/features/insights/hooks/useVisitorHeartbeat.js
+++ b/apps/client/src/features/insights/hooks/useVisitorHeartbeat.js
@@ -16,7 +16,6 @@ export default function useVisitorHeartbeat() {
     try {
       await fetchPublic("/analytics/heartbeat", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ path, isPageView }),
       });
     } catch {

--- a/apps/client/src/features/map/components/MarketMarkers.jsx
+++ b/apps/client/src/features/map/components/MarketMarkers.jsx
@@ -81,6 +81,7 @@ const MarketMarkers = ({
         properties: {
           cluster: false,
           marketIndex: index,
+          chainName: market.chain?.name || market.name,
         },
         geometry: {
           type: "Point",

--- a/apps/client/src/features/map/utils/markerUtils.js
+++ b/apps/client/src/features/map/utils/markerUtils.js
@@ -8,9 +8,8 @@ export const getClusterGradient = (cluster, supercluster) => {
     const chainCountMap = {};
 
     leaves.forEach((leaf) => {
-      const market = leaf.properties?.market;
-      if (!market) return;
-      const chainName = market.chain?.name || market.name;
+      const chainName = leaf.properties?.chainName;
+      if (!chainName) return;
       const normalizedName = chainName.trim().toLowerCase();
       chainCountMap[normalizedName] =
         (chainCountMap[normalizedName] || 0) + 1;

--- a/apps/server/src/modules/report/report.service.js
+++ b/apps/server/src/modules/report/report.service.js
@@ -127,10 +127,12 @@ export class ReportService {
 
       await fs.mkdir(REPORTS_DIR, { recursive: true });
       const fileName = `report-${jobIdStr}.csv`;
-      await fs.writeFile(path.join(REPORTS_DIR, fileName), csv, "utf-8");
+      const filePath = path.join(REPORTS_DIR, fileName);
+      await fs.writeFile(filePath, csv, "utf-8");
 
       const freshJob = await this.reportJobRepository.findById(jobId);
       if (!freshJob || freshJob.status === ReportJobStatus.CANCELLED || freshJob.status === ReportJobStatus.ABORTED) {
+        await fs.unlink(filePath).catch(() => {});
         return;
       }
 
@@ -139,6 +141,8 @@ export class ReportService {
       freshJob.finishedAt = new Date();
       await this.reportJobRepository.save(freshJob);
     } catch (err) {
+      const orphanPath = path.join(REPORTS_DIR, `report-${jobIdStr}.csv`);
+      await fs.unlink(orphanPath).catch(() => {});
       try {
         const job = await this.reportJobRepository.findById(jobId);
         if (job && job.status !== ReportJobStatus.CANCELLED && job.status !== ReportJobStatus.ABORTED) {


### PR DESCRIPTION
## Summary

Follow-up fixes identified during post-merge audit of the fetch migration.

## Changes

- **fix(client):** Add mutex to `refreshAccessToken` so concurrent 401 responses share a single refresh call instead of firing parallel requests. Also adds automatic `Content-Type: application/json` to `fetchPublic` (matching `fetchPrivate`), removing the need to set it manually at call sites
- **fix(map):** Restore cluster color gradient — the prior perf commit dropped the full market object from GeoJSON properties, which broke `getClusterGradient`. Now passes only `chainName` string to keep the gradient while avoiding serializing full market objects
- **fix(report):** Delete orphaned CSV file when report job fails or is cancelled after the file has already been written to disk

## Breaking Changes

None.